### PR TITLE
Block subsystem update for October (v6.11, v6.12-rc2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+
+{
+  description = "Shell for building rust-for-linux.com";
+  inputs.nixpkgs.url = "nixpkgs/nixos-24.05";
+  inputs.systems.url = "github:nix-systems/default";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.systems.follows = "systems";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell { packages = with pkgs; [
+          python3
+          mdbook
+        ]; };
+      }
+    );
+}

--- a/src/NVMe-driver.md
+++ b/src/NVMe-driver.md
@@ -24,6 +24,41 @@ The driver is not currently suitable for general use.
    [slides](https://lpc.events/event/16/contributions/1180/attachments/1017/1961/deck.pdf)
    and [video](https://lpc.events/event/16/contributions/1180/attachments/1017/2249/go)
 
+## 6.12-rc2 Rebase Performance ([`rnvme-v6.12-rc2`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnvme-v6.12-rc2))
+
+### Setup
+
+ - AMD Ryzen 5 7600
+ - 32 GB 4800 MT/s DDR5 on one channel
+ - 1x Samsung 990 Pro 1TB (PCIe 4.0 x4 16 GT/S)
+ - NixOS 24.05
+
+### Results
+
+- 40 samples
+- Difference of means modeled with t-distribution
+- P95 confidence intervals
+
+![](rnvme/nvme-v6.12-rc2-absolute.svg)
+
+![](rnvme/nvme-v6.12-rc2-relative.svg)
+
+The graph shows
+    <math>
+        <mfrac>
+            <mrow>
+                <mi>R</mi>
+                <mo>-</mo>
+                <mi>C</mi>
+            </mrow>
+            <mrow>
+                <mi>C</mi>
+            </mrow>
+        </mfrac>
+    </math>
+where C is IO/s for the C driver and R is IO/s for the Rust driver. Thus, negative
+means the C driver is faster while positive means the Rust driver is faster.
+
 ## 6.11 Rebase Performance ([`rnvme-v6.11`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnvme-v6.11))
 
 ### Setup

--- a/src/NVMe-driver.md
+++ b/src/NVMe-driver.md
@@ -24,6 +24,41 @@ The driver is not currently suitable for general use.
    [slides](https://lpc.events/event/16/contributions/1180/attachments/1017/1961/deck.pdf)
    and [video](https://lpc.events/event/16/contributions/1180/attachments/1017/2249/go)
 
+## 6.11 Rebase Performance ([`rnvme-v6.11`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnvme-v6.11))
+
+### Setup
+
+ - AMD Ryzen 5 7600
+ - 32 GB 4800 MT/s DDR5 on one channel
+ - 1x Samsung 990 Pro 1TB (PCIe 4.0 x4 16 GT/S)
+ - NixOS 24.05
+
+### Results
+
+- 40 samples
+- Difference of means modeled with t-distribution
+- P95 confidence intervals
+
+![](rnvme/nvme-v6.11-absolute.svg)
+
+![](rnvme/nvme-v6.11-relative.svg)
+
+The graph shows
+    <math>
+        <mfrac>
+            <mrow>
+                <mi>R</mi>
+                <mo>-</mo>
+                <mi>C</mi>
+            </mrow>
+            <mrow>
+                <mi>C</mi>
+            </mrow>
+        </mfrac>
+    </math>
+where C is IO/s for the C driver and R is IO/s for the Rust driver. Thus, negative
+means the C driver is faster while positive means the Rust driver is faster.
+
 ## 6.11-rc2 Rebase Performance ([`rnvme-v6.11-rc2`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnvme-v6.11-rc2))
 
 ### Setup

--- a/src/Null-Block-Driver.md
+++ b/src/Null-Block-Driver.md
@@ -67,6 +67,30 @@ in this work:
  - [Mailing List Post](https://lore.kernel.org/all/20230503090708.2524310-1-nmi@metaspace.dk/)
  - [Subset merged in v6.11-rc1](https://lore.kernel.org/all/20240611114551.228679-1-nmi@metaspace.dk/)
 
+## 6.12-rc2 Rebase ([`rnull-v6.12-rc2`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnull-v6.12-rc2))
+
+Changes from `rnull-v6.10`:
+
+ - Make `QueueData` references pinned.
+
+### Performance
+
+#### Setup
+
+ - AMD Ryzen 5 7600
+ - 32 GB 4800 MT/s DDR5 on one channel
+ - 1x Samsung 990 Pro 1TB (PCIe 4.0 x4 16 GT/S)
+ - NixOS 24.05
+
+#### Results
+
+- Plot shows `(mean_iops_r - mean_iops_c) / mean_iops_c`
+- 40 samples for each configuration
+- Difference of means modeled with t-distribution
+- P95 confidence intervals
+
+![](rnull/rnull-v6.12-rc2.svg)
+
 ## 6.11 Rebase ([`rnull-v6.11`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnull-v6.11))
 
 Changes from `rnull-v6.10`:

--- a/src/Null-Block-Driver.md
+++ b/src/Null-Block-Driver.md
@@ -67,6 +67,30 @@ in this work:
  - [Mailing List Post](https://lore.kernel.org/all/20230503090708.2524310-1-nmi@metaspace.dk/)
  - [Subset merged in v6.11-rc1](https://lore.kernel.org/all/20240611114551.228679-1-nmi@metaspace.dk/)
 
+## 6.11 Rebase ([`rnull-v6.11`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnull-v6.11))
+
+Changes from `rnull-v6.10`:
+
+ - None.
+
+### Performance
+
+#### Setup
+
+ - AMD Ryzen 5 7600
+ - 32 GB 4800 MT/s DDR5 on one channel
+ - 1x Samsung 990 Pro 1TB (PCIe 4.0 x4 16 GT/S)
+ - NixOS 24.05
+
+#### Results
+
+- Plot shows `(mean_iops_r - mean_iops_c) / mean_iops_c`
+- 40 samples for each configuration
+- Difference of means modeled with t-distribution
+- P95 confidence intervals
+
+![](rnull/rnull-v6.11.svg)
+
 ## 6.11-rc2 Rebase ([`rnull-v6.11-rc2`](https://git.kernel.org/pub/scm/linux/kernel/git/a.hindborg/linux.git/log/?h=rnull-v6.11-rc2))
 
 Changes from `rnull-v6.10`:

--- a/src/rnull/rnull-v6.11.svg
+++ b/src/rnull/rnull-v6.11.svg
@@ -1,0 +1,5044 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="936pt" height="432pt" viewBox="0 0 936 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432 
+L 936 432 
+L 936 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 75.38 210.650485 
+L 257.91 210.650485 
+L 257.91 94.23 
+L 75.38 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 93.633 210.650485 
+L 93.633 94.23 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m17097843b9" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m17097843b9" x="93.633" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 130.139 210.650485 
+L 130.139 94.23 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m17097843b9" x="130.139" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 166.645 210.650485 
+L 166.645 94.23 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m17097843b9" x="166.645" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 203.151 210.650485 
+L 203.151 94.23 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m17097843b9" x="203.151" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 239.657 210.650485 
+L 239.657 94.23 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m17097843b9" x="239.657" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 75.38 208.272735 
+L 257.91 208.272735 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m5f53fe7359" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="208.272735" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −0.2 -->
+      <g transform="translate(44.097188 212.071954) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-32" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 75.38 182.388469 
+L 257.91 182.388469 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="182.388469" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −0.1 -->
+      <g transform="translate(44.097188 186.187688) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 75.38 156.504203 
+L 257.91 156.504203 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="156.504203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.0 -->
+      <g transform="translate(52.476875 160.303422) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 75.38 130.619937 
+L 257.91 130.619937 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="130.619937" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.1 -->
+      <g transform="translate(52.476875 134.419155) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 75.38 104.735671 
+L 257.91 104.735671 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="104.735671" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.2 -->
+      <g transform="translate(52.476875 108.534889) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 75.38 195.330602 
+L 257.91 195.330602 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <defs>
+       <path id="md3ecc308ca" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="195.330602" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 75.38 169.446336 
+L 257.91 169.446336 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="169.446336" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 75.38 143.56207 
+L 257.91 143.56207 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="143.56207" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_27">
+      <path d="M 75.38 117.677804 
+L 257.91 117.677804 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="117.677804" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- randread -->
+     <g transform="translate(38.0175 175.160555) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-61" x="41.113281"/>
+      <use xlink:href="#DejaVuSans-6e" x="102.392578"/>
+      <use xlink:href="#DejaVuSans-64" x="165.771484"/>
+      <use xlink:href="#DejaVuSans-72" x="229.248047"/>
+      <use xlink:href="#DejaVuSans-65" x="268.111328"/>
+      <use xlink:href="#DejaVuSans-61" x="329.634766"/>
+      <use xlink:href="#DejaVuSans-64" x="390.914062"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.5065 156.504203 
+L 90.590833 156.504203 
+L 90.590833 149.70431 
+L 84.5065 149.70431 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 121.0125 156.504203 
+L 127.096833 156.504203 
+L 127.096833 112.568293 
+L 121.0125 112.568293 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 157.5185 156.504203 
+L 163.602833 156.504203 
+L 163.602833 140.251436 
+L 157.5185 140.251436 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 194.0245 156.504203 
+L 200.108833 156.504203 
+L 200.108833 160.557512 
+L 194.0245 160.557512 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 230.5305 156.504203 
+L 236.614833 156.504203 
+L 236.614833 180.916839 
+L 230.5305 180.916839 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 90.590833 156.504203 
+L 96.675167 156.504203 
+L 96.675167 141.607998 
+L 90.590833 141.607998 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 127.096833 156.504203 
+L 133.181167 156.504203 
+L 133.181167 148.346746 
+L 127.096833 148.346746 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 163.602833 156.504203 
+L 169.687167 156.504203 
+L 169.687167 159.517971 
+L 163.602833 159.517971 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 200.108833 156.504203 
+L 206.193167 156.504203 
+L 206.193167 181.395036 
+L 200.108833 181.395036 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 236.614833 156.504203 
+L 242.699167 156.504203 
+L 242.699167 175.38661 
+L 236.614833 175.38661 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 96.675167 156.504203 
+L 102.7595 156.504203 
+L 102.7595 131.207634 
+L 96.675167 131.207634 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 133.181167 156.504203 
+L 139.2655 156.504203 
+L 139.2655 152.782944 
+L 133.181167 152.782944 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 169.687167 156.504203 
+L 175.7715 156.504203 
+L 175.7715 160.648977 
+L 169.687167 160.648977 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 206.193167 156.504203 
+L 212.2775 156.504203 
+L 212.2775 180.551111 
+L 206.193167 180.551111 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 242.699167 156.504203 
+L 248.7835 156.504203 
+L 248.7835 172.248915 
+L 242.699167 172.248915 
+z
+" clip-path="url(#p0e557f1406)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 87.548667 152.203047 
+L 87.548667 147.205572 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 124.054667 116.524004 
+L 124.054667 108.612581 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 160.560667 148.260969 
+L 160.560667 132.241902 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 197.066667 166.630716 
+L 197.066667 154.484307 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 233.572667 183.936761 
+L 233.572667 177.896916 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_29">
+    <defs>
+     <path id="mcb9dfefa88" d="M 1.5 0 
+L -1.5 -0 
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="87.548667" y="152.203047" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="124.054667" y="116.524004" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="160.560667" y="148.260969" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="197.066667" y="166.630716" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="233.572667" y="183.936761" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_30">
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="87.548667" y="147.205572" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="124.054667" y="108.612581" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="160.560667" y="132.241902" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="197.066667" y="154.484307" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="233.572667" y="177.896916" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 93.633 146.748703 
+L 93.633 136.467293 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 130.139 160.448959 
+L 130.139 136.244533 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 166.645 171.235152 
+L 166.645 147.800791 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.151 186.631318 
+L 203.151 176.158754 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 239.657 177.991647 
+L 239.657 172.781572 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_31">
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="93.633" y="146.748703" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="130.139" y="160.448959" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="166.645" y="171.235152" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="203.151" y="186.631318" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="239.657" y="177.991647" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_32">
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="93.633" y="136.467293" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="130.139" y="136.244533" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="166.645" y="147.800791" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="203.151" y="176.158754" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="239.657" y="172.781572" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 99.717333 140.725858 
+L 99.717333 121.689409 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 136.223333 164.397209 
+L 136.223333 141.168679 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 172.729333 170.916423 
+L 172.729333 150.381531 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 209.235333 185.97859 
+L 209.235333 175.123632 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.741333 174.28519 
+L 245.741333 170.21264 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_33">
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="99.717333" y="140.725858" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="136.223333" y="164.397209" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="172.729333" y="170.916423" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="209.235333" y="185.97859" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="245.741333" y="174.28519" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_34">
+    <g clip-path="url(#p0e557f1406)">
+     <use xlink:href="#mcb9dfefa88" x="99.717333" y="121.689409" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="136.223333" y="141.168679" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="172.729333" y="150.381531" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="209.235333" y="175.123632" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="245.741333" y="170.21264" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_35">
+    <path d="M 75.38 156.504203 
+L 257.91 156.504203 
+" clip-path="url(#p0e557f1406)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 75.38 210.650485 
+L 75.38 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 257.91 210.650485 
+L 257.91 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 75.38 210.650485 
+L 257.91 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 75.38 94.23 
+L 257.91 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- qd 1 -->
+    <g transform="translate(153.3025 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-31" x="158.740234"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_22">
+    <path d="M 291.41 210.650485 
+L 473.94 210.650485 
+L 473.94 94.23 
+L 291.41 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_36">
+      <path d="M 309.663 210.650485 
+L 309.663 94.23 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m17097843b9" x="309.663" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_38">
+      <path d="M 346.169 210.650485 
+L 346.169 94.23 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m17097843b9" x="346.169" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_40">
+      <path d="M 382.675 210.650485 
+L 382.675 94.23 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m17097843b9" x="382.675" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_42">
+      <path d="M 419.181 210.650485 
+L 419.181 94.23 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m17097843b9" x="419.181" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_44">
+      <path d="M 455.687 210.650485 
+L 455.687 94.23 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m17097843b9" x="455.687" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_46">
+      <path d="M 291.41 208.272735 
+L 473.94 208.272735 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="208.272735" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_48">
+      <path d="M 291.41 182.388469 
+L 473.94 182.388469 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="182.388469" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_50">
+      <path d="M 291.41 156.504203 
+L 473.94 156.504203 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="156.504203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_52">
+      <path d="M 291.41 130.619937 
+L 473.94 130.619937 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="130.619937" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_54">
+      <path d="M 291.41 104.735671 
+L 473.94 104.735671 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="104.735671" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_56">
+      <path d="M 291.41 195.330602 
+L 473.94 195.330602 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="195.330602" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_58">
+      <path d="M 291.41 169.446336 
+L 473.94 169.446336 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="169.446336" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_60">
+      <path d="M 291.41 143.56207 
+L 473.94 143.56207 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="143.56207" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_62">
+      <path d="M 291.41 117.677804 
+L 473.94 117.677804 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="117.677804" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 300.5365 156.504203 
+L 306.620833 156.504203 
+L 306.620833 150.397393 
+L 300.5365 150.397393 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 337.0425 156.504203 
+L 343.126833 156.504203 
+L 343.126833 109.89492 
+L 337.0425 109.89492 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 373.5485 156.504203 
+L 379.632833 156.504203 
+L 379.632833 119.458609 
+L 373.5485 119.458609 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 410.0545 156.504203 
+L 416.138833 156.504203 
+L 416.138833 162.186526 
+L 410.0545 162.186526 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 446.5605 156.504203 
+L 452.644833 156.504203 
+L 452.644833 166.247243 
+L 446.5605 166.247243 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 306.620833 156.504203 
+L 312.705167 156.504203 
+L 312.705167 144.505594 
+L 306.620833 144.505594 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 343.126833 156.504203 
+L 349.211167 156.504203 
+L 349.211167 156.740446 
+L 343.126833 156.740446 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 379.632833 156.504203 
+L 385.717167 156.504203 
+L 385.717167 110.987811 
+L 379.632833 110.987811 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 416.138833 156.504203 
+L 422.223167 156.504203 
+L 422.223167 181.787776 
+L 416.138833 181.787776 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 452.644833 156.504203 
+L 458.729167 156.504203 
+L 458.729167 164.42662 
+L 452.644833 164.42662 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 312.705167 156.504203 
+L 318.7895 156.504203 
+L 318.7895 145.406775 
+L 312.705167 145.406775 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 349.211167 156.504203 
+L 355.2955 156.504203 
+L 355.2955 156.761761 
+L 349.211167 156.761761 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 385.717167 156.504203 
+L 391.8015 156.504203 
+L 391.8015 126.128383 
+L 385.717167 126.128383 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 422.223167 156.504203 
+L 428.3075 156.504203 
+L 428.3075 177.529481 
+L 422.223167 177.529481 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 458.729167 156.504203 
+L 464.8135 156.504203 
+L 464.8135 165.362758 
+L 458.729167 165.362758 
+z
+" clip-path="url(#pce634f8ef5)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 303.578667 152.957423 
+L 303.578667 147.837363 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 340.084667 113.781577 
+L 340.084667 106.008263 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 376.590667 125.660353 
+L 376.590667 113.256865 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 413.096667 165.315363 
+L 413.096667 159.05769 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 449.602667 168.279917 
+L 449.602667 164.214569 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_64">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="303.578667" y="152.957423" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="340.084667" y="113.781577" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="376.590667" y="125.660353" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="413.096667" y="165.315363" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="449.602667" y="168.279917" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_65">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="303.578667" y="147.837363" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="340.084667" y="106.008263" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="376.590667" y="113.256865" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="413.096667" y="159.05769" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="449.602667" y="164.214569" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_5">
+    <path d="M 309.663 149.827566 
+L 309.663 139.183621 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 346.169 171.120776 
+L 346.169 142.360116 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 382.675 120.967191 
+L 382.675 101.008431 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 419.181 187.328666 
+L 419.181 176.246886 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 455.687 165.771025 
+L 455.687 163.082216 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_66">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="309.663" y="149.827566" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="346.169" y="171.120776" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="382.675" y="120.967191" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="419.181" y="187.328666" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="455.687" y="165.771025" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_67">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="309.663" y="139.183621" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="346.169" y="142.360116" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="382.675" y="101.008431" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="419.181" y="176.246886" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="455.687" y="163.082216" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_6">
+    <path d="M 315.747333 158.672997 
+L 315.747333 132.140552 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 352.253333 168.907637 
+L 352.253333 144.615885 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 388.759333 137.174458 
+L 388.759333 115.082308 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 425.265333 179.094564 
+L 425.265333 175.964397 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 461.771333 166.684627 
+L 461.771333 164.040889 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_68">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="315.747333" y="158.672997" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="352.253333" y="168.907637" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="388.759333" y="137.174458" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="425.265333" y="179.094564" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="461.771333" y="166.684627" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_69">
+    <g clip-path="url(#pce634f8ef5)">
+     <use xlink:href="#mcb9dfefa88" x="315.747333" y="132.140552" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="352.253333" y="144.615885" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="388.759333" y="115.082308" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="425.265333" y="175.964397" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="461.771333" y="164.040889" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_70">
+    <path d="M 291.41 156.504203 
+L 473.94 156.504203 
+" clip-path="url(#pce634f8ef5)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 291.41 210.650485 
+L 291.41 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 473.94 210.650485 
+L 473.94 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 291.41 210.650485 
+L 473.94 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 291.41 94.23 
+L 473.94 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_8">
+    <!-- qd 8 -->
+    <g transform="translate(369.3325 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-38" x="158.740234"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_42">
+    <path d="M 507.44 210.650485 
+L 689.97 210.650485 
+L 689.97 94.23 
+L 507.44 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_11">
+     <g id="line2d_71">
+      <path d="M 525.693 210.650485 
+L 525.693 94.23 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m17097843b9" x="525.693" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_73">
+      <path d="M 562.199 210.650485 
+L 562.199 94.23 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m17097843b9" x="562.199" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_75">
+      <path d="M 598.705 210.650485 
+L 598.705 94.23 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m17097843b9" x="598.705" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_77">
+      <path d="M 635.211 210.650485 
+L 635.211 94.23 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m17097843b9" x="635.211" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_79">
+      <path d="M 671.717 210.650485 
+L 671.717 94.23 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m17097843b9" x="671.717" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_19">
+     <g id="line2d_81">
+      <path d="M 507.44 208.272735 
+L 689.97 208.272735 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="208.272735" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_83">
+      <path d="M 507.44 182.388469 
+L 689.97 182.388469 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="182.388469" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_85">
+      <path d="M 507.44 156.504203 
+L 689.97 156.504203 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="156.504203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_87">
+      <path d="M 507.44 130.619937 
+L 689.97 130.619937 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="130.619937" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_89">
+      <path d="M 507.44 104.735671 
+L 689.97 104.735671 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="104.735671" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_91">
+      <path d="M 507.44 195.330602 
+L 689.97 195.330602 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="195.330602" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_93">
+      <path d="M 507.44 169.446336 
+L 689.97 169.446336 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="169.446336" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_95">
+      <path d="M 507.44 143.56207 
+L 689.97 143.56207 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="143.56207" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_97">
+      <path d="M 507.44 117.677804 
+L 689.97 117.677804 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="117.677804" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_43">
+    <path d="M 516.5665 156.504203 
+L 522.650833 156.504203 
+L 522.650833 149.742606 
+L 516.5665 149.742606 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 553.0725 156.504203 
+L 559.156833 156.504203 
+L 559.156833 114.295477 
+L 553.0725 114.295477 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 589.5785 156.504203 
+L 595.662833 156.504203 
+L 595.662833 116.027796 
+L 589.5785 116.027796 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 626.0845 156.504203 
+L 632.168833 156.504203 
+L 632.168833 178.903558 
+L 626.0845 178.903558 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 662.5905 156.504203 
+L 668.674833 156.504203 
+L 668.674833 164.623468 
+L 662.5905 164.623468 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 522.650833 156.504203 
+L 528.735167 156.504203 
+L 528.735167 151.864018 
+L 522.650833 151.864018 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 559.156833 156.504203 
+L 565.241167 156.504203 
+L 565.241167 170.185369 
+L 559.156833 170.185369 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 595.662833 156.504203 
+L 601.747167 156.504203 
+L 601.747167 122.621402 
+L 595.662833 122.621402 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 632.168833 156.504203 
+L 638.253167 156.504203 
+L 638.253167 173.472747 
+L 632.168833 173.472747 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 668.674833 156.504203 
+L 674.759167 156.504203 
+L 674.759167 164.939164 
+L 668.674833 164.939164 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 528.735167 156.504203 
+L 534.8195 156.504203 
+L 534.8195 146.59798 
+L 528.735167 146.59798 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 565.241167 156.504203 
+L 571.3255 156.504203 
+L 571.3255 162.723574 
+L 565.241167 162.723574 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 601.747167 156.504203 
+L 607.8315 156.504203 
+L 607.8315 171.362746 
+L 601.747167 171.362746 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 638.253167 156.504203 
+L 644.3375 156.504203 
+L 644.3375 170.071066 
+L 638.253167 170.071066 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 674.759167 156.504203 
+L 680.8435 156.504203 
+L 680.8435 165.684734 
+L 674.759167 165.684734 
+z
+" clip-path="url(#p124370f7f8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_7">
+    <path d="M 519.608667 152.176882 
+L 519.608667 147.30833 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 556.114667 124.566389 
+L 556.114667 104.024566 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 592.620667 121.161595 
+L 592.620667 110.893996 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 629.126667 181.693675 
+L 629.126667 176.113441 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 665.632667 165.789553 
+L 665.632667 163.457383 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_99">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="519.608667" y="152.176882" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="556.114667" y="124.566389" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="592.620667" y="121.161595" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="629.126667" y="181.693675" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="665.632667" y="165.789553" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_100">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="519.608667" y="147.30833" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="556.114667" y="104.024566" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="592.620667" y="110.893996" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="629.126667" y="176.113441" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="665.632667" y="163.457383" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_8">
+    <path d="M 525.693 158.97867 
+L 525.693 144.749365 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 562.199 185.713305 
+L 562.199 154.657433 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 598.705 130.533231 
+L 598.705 114.709574 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 635.211 174.956013 
+L 635.211 171.989481 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 671.717 166.083189 
+L 671.717 163.795139 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_101">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="525.693" y="158.97867" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="562.199" y="185.713305" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="598.705" y="130.533231" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="635.211" y="174.956013" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="671.717" y="166.083189" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_102">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="525.693" y="144.749365" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="562.199" y="154.657433" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="598.705" y="114.709574" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="635.211" y="171.989481" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="671.717" y="163.795139" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_9">
+    <path d="M 531.777333 158.509979 
+L 531.777333 134.685981 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 568.283333 172.24682 
+L 568.283333 153.200328 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 604.789333 173.108514 
+L 604.789333 169.616979 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 641.295333 172.788236 
+L 641.295333 167.353897 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 677.801333 166.757578 
+L 677.801333 164.61189 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_103">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="531.777333" y="158.509979" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="568.283333" y="172.24682" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="604.789333" y="173.108514" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="641.295333" y="172.788236" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="677.801333" y="166.757578" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_104">
+    <g clip-path="url(#p124370f7f8)">
+     <use xlink:href="#mcb9dfefa88" x="531.777333" y="134.685981" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="568.283333" y="153.200328" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="604.789333" y="169.616979" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="641.295333" y="167.353897" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="677.801333" y="164.61189" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_105">
+    <path d="M 507.44 156.504203 
+L 689.97 156.504203 
+" clip-path="url(#p124370f7f8)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 507.44 210.650485 
+L 507.44 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 689.97 210.650485 
+L 689.97 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 507.44 210.650485 
+L 689.97 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 507.44 94.23 
+L 689.97 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_9">
+    <!-- qd 32 -->
+    <g transform="translate(581.545 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-33" x="158.740234"/>
+     <use xlink:href="#DejaVuSans-32" x="222.363281"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_62">
+    <path d="M 723.47 210.650485 
+L 906 210.650485 
+L 906 94.23 
+L 723.47 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_16">
+     <g id="line2d_106">
+      <path d="M 741.723 210.650485 
+L 741.723 94.23 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#m17097843b9" x="741.723" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_108">
+      <path d="M 778.229 210.650485 
+L 778.229 94.23 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#m17097843b9" x="778.229" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_110">
+      <path d="M 814.735 210.650485 
+L 814.735 94.23 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#m17097843b9" x="814.735" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_112">
+      <path d="M 851.241 210.650485 
+L 851.241 94.23 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#m17097843b9" x="851.241" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_114">
+      <path d="M 887.747 210.650485 
+L 887.747 94.23 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#m17097843b9" x="887.747" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_28">
+     <g id="line2d_116">
+      <path d="M 723.47 208.272735 
+L 906 208.272735 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="208.272735" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_118">
+      <path d="M 723.47 182.388469 
+L 906 182.388469 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="182.388469" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_120">
+      <path d="M 723.47 156.504203 
+L 906 156.504203 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="156.504203" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_122">
+      <path d="M 723.47 130.619937 
+L 906 130.619937 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="130.619937" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_124">
+      <path d="M 723.47 104.735671 
+L 906 104.735671 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="104.735671" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_126">
+      <path d="M 723.47 195.330602 
+L 906 195.330602 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_127">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="195.330602" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_128">
+      <path d="M 723.47 169.446336 
+L 906 169.446336 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_129">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="169.446336" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_130">
+      <path d="M 723.47 143.56207 
+L 906 143.56207 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_131">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="143.56207" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_132">
+      <path d="M 723.47 117.677804 
+L 906 117.677804 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_133">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="117.677804" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_63">
+    <path d="M 732.5965 156.504203 
+L 738.680833 156.504203 
+L 738.680833 153.880237 
+L 732.5965 153.880237 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 769.1025 156.504203 
+L 775.186833 156.504203 
+L 775.186833 103.433686 
+L 769.1025 103.433686 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 805.6085 156.504203 
+L 811.692833 156.504203 
+L 811.692833 175.426679 
+L 805.6085 175.426679 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 842.1145 156.504203 
+L 848.198833 156.504203 
+L 848.198833 167.884425 
+L 842.1145 167.884425 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 878.6205 156.504203 
+L 884.704833 156.504203 
+L 884.704833 164.991848 
+L 878.6205 164.991848 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_68">
+    <path d="M 738.680833 156.504203 
+L 744.765167 156.504203 
+L 744.765167 152.931469 
+L 738.680833 152.931469 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_69">
+    <path d="M 775.186833 156.504203 
+L 781.271167 156.504203 
+L 781.271167 141.935566 
+L 775.186833 141.935566 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_70">
+    <path d="M 811.692833 156.504203 
+L 817.777167 156.504203 
+L 817.777167 166.481633 
+L 811.692833 166.481633 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_71">
+    <path d="M 848.198833 156.504203 
+L 854.283167 156.504203 
+L 854.283167 164.802458 
+L 848.198833 164.802458 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_72">
+    <path d="M 884.704833 156.504203 
+L 890.789167 156.504203 
+L 890.789167 165.028493 
+L 884.704833 165.028493 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_73">
+    <path d="M 744.765167 156.504203 
+L 750.8495 156.504203 
+L 750.8495 144.25709 
+L 744.765167 144.25709 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_74">
+    <path d="M 781.271167 156.504203 
+L 787.3555 156.504203 
+L 787.3555 143.35023 
+L 781.271167 143.35023 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_75">
+    <path d="M 817.777167 156.504203 
+L 823.8615 156.504203 
+L 823.8615 162.931006 
+L 817.777167 162.931006 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_76">
+    <path d="M 854.283167 156.504203 
+L 860.3675 156.504203 
+L 860.3675 169.184422 
+L 854.283167 169.184422 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_77">
+    <path d="M 890.789167 156.504203 
+L 896.8735 156.504203 
+L 896.8735 165.866889 
+L 890.789167 165.866889 
+z
+" clip-path="url(#p8fcfa6f282)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_10">
+    <path d="M 735.638667 158.09026 
+L 735.638667 149.670214 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 772.144667 107.345533 
+L 772.144667 99.52184 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 808.650667 177.777717 
+L 808.650667 173.075642 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 845.156667 169.492461 
+L 845.156667 166.276389 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 881.662667 166.054833 
+L 881.662667 163.928864 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_134">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="735.638667" y="158.09026" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="772.144667" y="107.345533" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="808.650667" y="177.777717" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="845.156667" y="169.492461" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="881.662667" y="166.054833" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_135">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="735.638667" y="149.670214" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="772.144667" y="99.52184" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="808.650667" y="173.075642" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="845.156667" y="166.276389" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="881.662667" y="163.928864" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_11">
+    <path d="M 741.723 161.005574 
+L 741.723 144.857363 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 778.229 154.506662 
+L 778.229 129.36447 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 814.735 167.791259 
+L 814.735 165.172007 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 851.241 166.373514 
+L 851.241 163.231403 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 887.747 166.113233 
+L 887.747 163.943753 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_136">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="741.723" y="161.005574" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="778.229" y="154.506662" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="814.735" y="167.791259" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="851.241" y="166.373514" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="887.747" y="166.113233" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_137">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="741.723" y="144.857363" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="778.229" y="129.36447" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="814.735" y="165.172007" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="851.241" y="163.231403" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="887.747" y="163.943753" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_12">
+    <path d="M 747.807333 156.281053 
+L 747.807333 132.233126 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 784.313333 149.2998 
+L 784.313333 137.400661 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 820.819333 165.888753 
+L 820.819333 159.973258 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 857.325333 172.125872 
+L 857.325333 166.242971 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 893.831333 166.963406 
+L 893.831333 164.770373 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_138">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="747.807333" y="156.281053" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="784.313333" y="149.2998" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="820.819333" y="165.888753" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="857.325333" y="172.125872" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="893.831333" y="166.963406" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_139">
+    <g clip-path="url(#p8fcfa6f282)">
+     <use xlink:href="#mcb9dfefa88" x="747.807333" y="132.233126" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="784.313333" y="137.400661" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="820.819333" y="159.973258" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="857.325333" y="166.242971" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="893.831333" y="164.770373" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_140">
+    <path d="M 723.47 156.504203 
+L 906 156.504203 
+" clip-path="url(#p8fcfa6f282)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_78">
+    <path d="M 723.47 210.650485 
+L 723.47 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_79">
+    <path d="M 906 210.650485 
+L 906 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_80">
+    <path d="M 723.47 210.650485 
+L 906 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_81">
+    <path d="M 723.47 94.23 
+L 906 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- qd 128 -->
+    <g transform="translate(793.7575 88.23) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-31" x="158.740234"/>
+     <use xlink:href="#DejaVuSans-32" x="222.363281"/>
+     <use xlink:href="#DejaVuSans-38" x="285.986328"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_82">
+    <path d="M 75.38 360.570971 
+L 257.91 360.570971 
+L 257.91 244.150485 
+L 75.38 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_21">
+     <g id="line2d_141">
+      <path d="M 93.633 360.570971 
+L 93.633 244.150485 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m17097843b9" x="93.633" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 4 KiB -->
+      <g transform="translate(80.806746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_143">
+      <path d="M 130.139 360.570971 
+L 130.139 244.150485 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m17097843b9" x="130.139" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 32 KiB -->
+      <g transform="translate(112.813779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_145">
+      <path d="M 166.645 360.570971 
+L 166.645 244.150485 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m17097843b9" x="166.645" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 256 KiB -->
+      <g transform="translate(144.820812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_147">
+      <path d="M 203.151 360.570971 
+L 203.151 244.150485 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m17097843b9" x="203.151" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1 MiB -->
+      <g transform="translate(188.860814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_149">
+      <path d="M 239.657 360.570971 
+L 239.657 244.150485 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m17097843b9" x="239.657" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 16 MiB -->
+      <g transform="translate(220.867847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10">
+    <g id="ytick_37">
+     <g id="line2d_151">
+      <path d="M 75.38 358.19322 
+L 257.91 358.19322 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="358.19322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- −0.2 -->
+      <g transform="translate(44.097188 361.992439) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-32" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_153">
+      <path d="M 75.38 332.308954 
+L 257.91 332.308954 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="332.308954" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- −0.1 -->
+      <g transform="translate(44.097188 336.108173) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_155">
+      <path d="M 75.38 306.424688 
+L 257.91 306.424688 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="306.424688" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0.0 -->
+      <g transform="translate(52.476875 310.223907) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_157">
+      <path d="M 75.38 280.540422 
+L 257.91 280.540422 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="280.540422" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 0.1 -->
+      <g transform="translate(52.476875 284.339641) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_159">
+      <path d="M 75.38 254.656156 
+L 257.91 254.656156 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="75.38" y="254.656156" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0.2 -->
+      <g transform="translate(52.476875 258.455375) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_161">
+      <path d="M 75.38 345.251087 
+L 257.91 345.251087 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="345.251087" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_163">
+      <path d="M 75.38 319.366821 
+L 257.91 319.366821 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="319.366821" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_165">
+      <path d="M 75.38 293.482555 
+L 257.91 293.482555 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_166">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="293.482555" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_167">
+      <path d="M 75.38 267.598289 
+L 257.91 267.598289 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_168">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="75.38" y="267.598289" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- randwrite -->
+     <g transform="translate(38.0175 326.393541) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-61" x="41.113281"/>
+      <use xlink:href="#DejaVuSans-6e" x="102.392578"/>
+      <use xlink:href="#DejaVuSans-64" x="165.771484"/>
+      <use xlink:href="#DejaVuSans-77" x="229.248047"/>
+      <use xlink:href="#DejaVuSans-72" x="311.035156"/>
+      <use xlink:href="#DejaVuSans-69" x="352.148438"/>
+      <use xlink:href="#DejaVuSans-74" x="379.931641"/>
+      <use xlink:href="#DejaVuSans-65" x="419.140625"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_83">
+    <path d="M 84.5065 306.424688 
+L 90.590833 306.424688 
+L 90.590833 310.038185 
+L 84.5065 310.038185 
+z
+" clip-path="url(#p3be495d188)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_84">
+    <path d="M 121.0125 306.424688 
+L 127.096833 306.424688 
+L 127.096833 315.57491 
+L 121.0125 315.57491 
+z
+" clip-path="url(#p3be495d188)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_85">
+    <path d="M 157.5185 306.424688 
+L 163.602833 306.424688 
+L 163.602833 321.705802 
+L 157.5185 321.705802 
+z
+" clip-path="url(#p3be495d188)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_86">
+    <path d="M 194.0245 306.424688 
+L 200.108833 306.424688 
+L 200.108833 314.159371 
+L 194.0245 314.159371 
+z
+" clip-path="url(#p3be495d188)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_87">
+    <path d="M 230.5305 306.424688 
+L 236.614833 306.424688 
+L 236.614833 326.687624 
+L 230.5305 326.687624 
+z
+" clip-path="url(#p3be495d188)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_88">
+    <path d="M 90.590833 306.424688 
+L 96.675167 306.424688 
+L 96.675167 298.438062 
+L 90.590833 298.438062 
+z
+" clip-path="url(#p3be495d188)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_89">
+    <path d="M 127.096833 306.424688 
+L 133.181167 306.424688 
+L 133.181167 314.285726 
+L 127.096833 314.285726 
+z
+" clip-path="url(#p3be495d188)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_90">
+    <path d="M 163.602833 306.424688 
+L 169.687167 306.424688 
+L 169.687167 324.207451 
+L 163.602833 324.207451 
+z
+" clip-path="url(#p3be495d188)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_91">
+    <path d="M 200.108833 306.424688 
+L 206.193167 306.424688 
+L 206.193167 314.347889 
+L 200.108833 314.347889 
+z
+" clip-path="url(#p3be495d188)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_92">
+    <path d="M 236.614833 306.424688 
+L 242.699167 306.424688 
+L 242.699167 326.741346 
+L 236.614833 326.741346 
+z
+" clip-path="url(#p3be495d188)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_93">
+    <path d="M 96.675167 306.424688 
+L 102.7595 306.424688 
+L 102.7595 308.906043 
+L 96.675167 308.906043 
+z
+" clip-path="url(#p3be495d188)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_94">
+    <path d="M 133.181167 306.424688 
+L 139.2655 306.424688 
+L 139.2655 311.559554 
+L 133.181167 311.559554 
+z
+" clip-path="url(#p3be495d188)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_95">
+    <path d="M 169.687167 306.424688 
+L 175.7715 306.424688 
+L 175.7715 323.920749 
+L 169.687167 323.920749 
+z
+" clip-path="url(#p3be495d188)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_96">
+    <path d="M 206.193167 306.424688 
+L 212.2775 306.424688 
+L 212.2775 314.400959 
+L 206.193167 314.400959 
+z
+" clip-path="url(#p3be495d188)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_97">
+    <path d="M 242.699167 306.424688 
+L 248.7835 306.424688 
+L 248.7835 317.239458 
+L 242.699167 317.239458 
+z
+" clip-path="url(#p3be495d188)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_13">
+    <path d="M 87.548667 313.842774 
+L 87.548667 306.233596 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 124.054667 318.248797 
+L 124.054667 312.901022 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 160.560667 324.270863 
+L 160.560667 319.14074 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 197.066667 318.16922 
+L 197.066667 310.149522 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 233.572667 329.24531 
+L 233.572667 324.129937 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_169">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="87.548667" y="313.842774" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="124.054667" y="318.248797" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="160.560667" y="324.270863" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="197.066667" y="318.16922" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="233.572667" y="329.24531" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_170">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="87.548667" y="306.233596" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="124.054667" y="312.901022" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="160.560667" y="319.14074" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="197.066667" y="310.149522" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="233.572667" y="324.129937" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_14">
+    <path d="M 93.633 303.542249 
+L 93.633 293.333875 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 130.139 344.476134 
+L 130.139 284.095317 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 166.645 326.377164 
+L 166.645 322.037738 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.151 317.827077 
+L 203.151 310.868701 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 239.657 328.621704 
+L 239.657 324.860987 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_171">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="93.633" y="303.542249" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="130.139" y="344.476134" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="166.645" y="326.377164" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="203.151" y="317.827077" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="239.657" y="328.621704" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_172">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="93.633" y="293.333875" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="130.139" y="284.095317" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="166.645" y="322.037738" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="203.151" y="310.868701" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="239.657" y="324.860987" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_15">
+    <path d="M 99.717333 313.248802 
+L 99.717333 304.563284 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 136.223333 318.688397 
+L 136.223333 304.430712 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 172.729333 326.141124 
+L 172.729333 321.700374 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 209.235333 323.705565 
+L 209.235333 305.096353 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.741333 319.226619 
+L 245.741333 315.252298 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_173">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="99.717333" y="313.248802" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="136.223333" y="318.688397" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="172.729333" y="326.141124" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="209.235333" y="323.705565" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="245.741333" y="319.226619" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_174">
+    <g clip-path="url(#p3be495d188)">
+     <use xlink:href="#mcb9dfefa88" x="99.717333" y="304.563284" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="136.223333" y="304.430712" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="172.729333" y="321.700374" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="209.235333" y="305.096353" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="245.741333" y="315.252298" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_175">
+    <path d="M 75.38 306.424688 
+L 257.91 306.424688 
+" clip-path="url(#p3be495d188)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_98">
+    <path d="M 75.38 360.570971 
+L 75.38 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_99">
+    <path d="M 257.91 360.570971 
+L 257.91 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_100">
+    <path d="M 75.38 360.570971 
+L 257.91 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_101">
+    <path d="M 75.38 244.150485 
+L 257.91 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_6">
+   <g id="patch_102">
+    <path d="M 291.41 360.570971 
+L 473.94 360.570971 
+L 473.94 244.150485 
+L 291.41 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_11">
+    <g id="xtick_26">
+     <g id="line2d_176">
+      <path d="M 309.663 360.570971 
+L 309.663 244.150485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_177">
+      <g>
+       <use xlink:href="#m17097843b9" x="309.663" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 KiB -->
+      <g transform="translate(296.836746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_178">
+      <path d="M 346.169 360.570971 
+L 346.169 244.150485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_179">
+      <g>
+       <use xlink:href="#m17097843b9" x="346.169" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 32 KiB -->
+      <g transform="translate(328.843779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_180">
+      <path d="M 382.675 360.570971 
+L 382.675 244.150485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_181">
+      <g>
+       <use xlink:href="#m17097843b9" x="382.675" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 256 KiB -->
+      <g transform="translate(360.850812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_182">
+      <path d="M 419.181 360.570971 
+L 419.181 244.150485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_183">
+      <g>
+       <use xlink:href="#m17097843b9" x="419.181" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 1 MiB -->
+      <g transform="translate(404.890814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_184">
+      <path d="M 455.687 360.570971 
+L 455.687 244.150485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_185">
+      <g>
+       <use xlink:href="#m17097843b9" x="455.687" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 16 MiB -->
+      <g transform="translate(436.897847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_12">
+    <g id="ytick_46">
+     <g id="line2d_186">
+      <path d="M 291.41 358.19322 
+L 473.94 358.19322 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_187">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="358.19322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_188">
+      <path d="M 291.41 332.308954 
+L 473.94 332.308954 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_189">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="332.308954" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_190">
+      <path d="M 291.41 306.424688 
+L 473.94 306.424688 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_191">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="306.424688" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_192">
+      <path d="M 291.41 280.540422 
+L 473.94 280.540422 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_193">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="280.540422" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_194">
+      <path d="M 291.41 254.656156 
+L 473.94 254.656156 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_195">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="291.41" y="254.656156" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_196">
+      <path d="M 291.41 345.251087 
+L 473.94 345.251087 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_197">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="345.251087" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_198">
+      <path d="M 291.41 319.366821 
+L 473.94 319.366821 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_199">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="319.366821" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_200">
+      <path d="M 291.41 293.482555 
+L 473.94 293.482555 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_201">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="293.482555" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_202">
+      <path d="M 291.41 267.598289 
+L 473.94 267.598289 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_203">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="291.41" y="267.598289" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_103">
+    <path d="M 300.5365 306.424688 
+L 306.620833 306.424688 
+L 306.620833 311.709161 
+L 300.5365 311.709161 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_104">
+    <path d="M 337.0425 306.424688 
+L 343.126833 306.424688 
+L 343.126833 308.938133 
+L 337.0425 308.938133 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_105">
+    <path d="M 373.5485 306.424688 
+L 379.632833 306.424688 
+L 379.632833 330.095815 
+L 373.5485 330.095815 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_106">
+    <path d="M 410.0545 306.424688 
+L 416.138833 306.424688 
+L 416.138833 328.999979 
+L 410.0545 328.999979 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_107">
+    <path d="M 446.5605 306.424688 
+L 452.644833 306.424688 
+L 452.644833 317.104063 
+L 446.5605 317.104063 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_108">
+    <path d="M 306.620833 306.424688 
+L 312.705167 306.424688 
+L 312.705167 303.152433 
+L 306.620833 303.152433 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_109">
+    <path d="M 343.126833 306.424688 
+L 349.211167 306.424688 
+L 349.211167 324.49741 
+L 343.126833 324.49741 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_110">
+    <path d="M 379.632833 306.424688 
+L 385.717167 306.424688 
+L 385.717167 330.936022 
+L 379.632833 330.936022 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_111">
+    <path d="M 416.138833 306.424688 
+L 422.223167 306.424688 
+L 422.223167 329.727879 
+L 416.138833 329.727879 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_112">
+    <path d="M 452.644833 306.424688 
+L 458.729167 306.424688 
+L 458.729167 316.130506 
+L 452.644833 316.130506 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_113">
+    <path d="M 312.705167 306.424688 
+L 318.7895 306.424688 
+L 318.7895 306.601853 
+L 312.705167 306.601853 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_114">
+    <path d="M 349.211167 306.424688 
+L 355.2955 306.424688 
+L 355.2955 296.585664 
+L 349.211167 296.585664 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_115">
+    <path d="M 385.717167 306.424688 
+L 391.8015 306.424688 
+L 391.8015 331.161705 
+L 385.717167 331.161705 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_116">
+    <path d="M 422.223167 306.424688 
+L 428.3075 306.424688 
+L 428.3075 326.112603 
+L 422.223167 326.112603 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_117">
+    <path d="M 458.729167 306.424688 
+L 464.8135 306.424688 
+L 464.8135 316.288004 
+L 458.729167 316.288004 
+z
+" clip-path="url(#p9c1e6e133a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_16">
+    <path d="M 303.578667 316.681087 
+L 303.578667 306.737236 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 340.084667 311.8576 
+L 340.084667 306.018667 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 376.590667 331.793365 
+L 376.590667 328.398265 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 413.096667 331.186558 
+L 413.096667 326.813401 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 449.602667 318.492277 
+L 449.602667 315.715848 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_204">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="303.578667" y="316.681087" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="340.084667" y="311.8576" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="376.590667" y="331.793365" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="413.096667" y="331.186558" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="449.602667" y="318.492277" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_205">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="303.578667" y="306.737236" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="340.084667" y="306.018667" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="376.590667" y="328.398265" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="413.096667" y="326.813401" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="449.602667" y="315.715848" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_17">
+    <path d="M 309.663 310.280286 
+L 309.663 296.024579 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 346.169 354.150354 
+L 346.169 294.844466 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 382.675 332.549243 
+L 382.675 329.322801 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 419.181 332.008248 
+L 419.181 327.44751 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 455.687 321.173528 
+L 455.687 311.087485 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_206">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="309.663" y="310.280286" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="346.169" y="354.150354" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="382.675" y="332.549243" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="419.181" y="332.008248" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="455.687" y="321.173528" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_207">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="309.663" y="296.024579" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="346.169" y="294.844466" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="382.675" y="329.322801" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="419.181" y="327.44751" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="455.687" y="311.087485" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_18">
+    <path d="M 315.747333 312.897945 
+L 315.747333 300.305762 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 352.253333 300.584356 
+L 352.253333 292.586972 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 388.759333 332.834843 
+L 388.759333 329.488566 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 425.265333 329.285663 
+L 425.265333 322.939543 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 461.771333 317.477214 
+L 461.771333 315.098793 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_208">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="315.747333" y="312.897945" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="352.253333" y="300.584356" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="388.759333" y="332.834843" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="425.265333" y="329.285663" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="461.771333" y="317.477214" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_209">
+    <g clip-path="url(#p9c1e6e133a)">
+     <use xlink:href="#mcb9dfefa88" x="315.747333" y="300.305762" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="352.253333" y="292.586972" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="388.759333" y="329.488566" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="425.265333" y="322.939543" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="461.771333" y="315.098793" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_210">
+    <path d="M 291.41 306.424688 
+L 473.94 306.424688 
+" clip-path="url(#p9c1e6e133a)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_118">
+    <path d="M 291.41 360.570971 
+L 291.41 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_119">
+    <path d="M 473.94 360.570971 
+L 473.94 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_120">
+    <path d="M 291.41 360.570971 
+L 473.94 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_121">
+    <path d="M 291.41 244.150485 
+L 473.94 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_7">
+   <g id="patch_122">
+    <path d="M 507.44 360.570971 
+L 689.97 360.570971 
+L 689.97 244.150485 
+L 507.44 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_13">
+    <g id="xtick_31">
+     <g id="line2d_211">
+      <path d="M 525.693 360.570971 
+L 525.693 244.150485 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_212">
+      <g>
+       <use xlink:href="#m17097843b9" x="525.693" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 4 KiB -->
+      <g transform="translate(512.866746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_213">
+      <path d="M 562.199 360.570971 
+L 562.199 244.150485 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_214">
+      <g>
+       <use xlink:href="#m17097843b9" x="562.199" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 32 KiB -->
+      <g transform="translate(544.873779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_215">
+      <path d="M 598.705 360.570971 
+L 598.705 244.150485 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_216">
+      <g>
+       <use xlink:href="#m17097843b9" x="598.705" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 256 KiB -->
+      <g transform="translate(576.880812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_217">
+      <path d="M 635.211 360.570971 
+L 635.211 244.150485 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_218">
+      <g>
+       <use xlink:href="#m17097843b9" x="635.211" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 1 MiB -->
+      <g transform="translate(620.920814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_219">
+      <path d="M 671.717 360.570971 
+L 671.717 244.150485 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_220">
+      <g>
+       <use xlink:href="#m17097843b9" x="671.717" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 16 MiB -->
+      <g transform="translate(652.927847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_14">
+    <g id="ytick_55">
+     <g id="line2d_221">
+      <path d="M 507.44 358.19322 
+L 689.97 358.19322 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_222">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="358.19322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_223">
+      <path d="M 507.44 332.308954 
+L 689.97 332.308954 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_224">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="332.308954" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_57">
+     <g id="line2d_225">
+      <path d="M 507.44 306.424688 
+L 689.97 306.424688 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_226">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="306.424688" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_227">
+      <path d="M 507.44 280.540422 
+L 689.97 280.540422 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_228">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="280.540422" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_229">
+      <path d="M 507.44 254.656156 
+L 689.97 254.656156 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_230">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="507.44" y="254.656156" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_231">
+      <path d="M 507.44 345.251087 
+L 689.97 345.251087 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_232">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="345.251087" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_233">
+      <path d="M 507.44 319.366821 
+L 689.97 319.366821 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_234">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="319.366821" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_235">
+      <path d="M 507.44 293.482555 
+L 689.97 293.482555 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_236">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="293.482555" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_63">
+     <g id="line2d_237">
+      <path d="M 507.44 267.598289 
+L 689.97 267.598289 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_238">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="507.44" y="267.598289" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_123">
+    <path d="M 516.5665 306.424688 
+L 522.650833 306.424688 
+L 522.650833 307.824056 
+L 516.5665 307.824056 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_124">
+    <path d="M 553.0725 306.424688 
+L 559.156833 306.424688 
+L 559.156833 314.242599 
+L 553.0725 314.242599 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_125">
+    <path d="M 589.5785 306.424688 
+L 595.662833 306.424688 
+L 595.662833 330.133344 
+L 589.5785 330.133344 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_126">
+    <path d="M 626.0845 306.424688 
+L 632.168833 306.424688 
+L 632.168833 327.289923 
+L 626.0845 327.289923 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_127">
+    <path d="M 662.5905 306.424688 
+L 668.674833 306.424688 
+L 668.674833 317.236266 
+L 662.5905 317.236266 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_128">
+    <path d="M 522.650833 306.424688 
+L 528.735167 306.424688 
+L 528.735167 300.537962 
+L 522.650833 300.537962 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_129">
+    <path d="M 559.156833 306.424688 
+L 565.241167 306.424688 
+L 565.241167 312.325517 
+L 559.156833 312.325517 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_130">
+    <path d="M 595.662833 306.424688 
+L 601.747167 306.424688 
+L 601.747167 330.861524 
+L 595.662833 330.861524 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_131">
+    <path d="M 632.168833 306.424688 
+L 638.253167 306.424688 
+L 638.253167 326.945059 
+L 632.168833 326.945059 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_132">
+    <path d="M 668.674833 306.424688 
+L 674.759167 306.424688 
+L 674.759167 315.288471 
+L 668.674833 315.288471 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_133">
+    <path d="M 528.735167 306.424688 
+L 534.8195 306.424688 
+L 534.8195 307.967706 
+L 528.735167 307.967706 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_134">
+    <path d="M 565.241167 306.424688 
+L 571.3255 306.424688 
+L 571.3255 315.763888 
+L 565.241167 315.763888 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_135">
+    <path d="M 601.747167 306.424688 
+L 607.8315 306.424688 
+L 607.8315 324.180123 
+L 601.747167 324.180123 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_136">
+    <path d="M 638.253167 306.424688 
+L 644.3375 306.424688 
+L 644.3375 317.758532 
+L 638.253167 317.758532 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_137">
+    <path d="M 674.759167 306.424688 
+L 680.8435 306.424688 
+L 680.8435 316.029381 
+L 674.759167 316.029381 
+z
+" clip-path="url(#p68a42ee260)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_19">
+    <path d="M 519.608667 312.295988 
+L 519.608667 303.352123 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 556.114667 316.812852 
+L 556.114667 311.672346 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 592.620667 332.041219 
+L 592.620667 328.225468 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 629.126667 329.123058 
+L 629.126667 325.456787 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 665.632667 318.575257 
+L 665.632667 315.897274 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_239">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="519.608667" y="312.295988" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="556.114667" y="316.812852" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="592.620667" y="332.041219" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="629.126667" y="329.123058" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="665.632667" y="318.575257" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_240">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="519.608667" y="303.352123" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="556.114667" y="311.672346" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="592.620667" y="328.225468" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="629.126667" y="325.456787" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="665.632667" y="315.897274" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_20">
+    <path d="M 525.693 307.435946 
+L 525.693 293.639978 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 562.199 341.741144 
+L 562.199 282.90989 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 598.705 332.698086 
+L 598.705 329.024961 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 635.211 333.177284 
+L 635.211 320.712834 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 671.717 317.237246 
+L 671.717 313.339696 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_241">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="525.693" y="307.435946" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="562.199" y="341.741144" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="598.705" y="332.698086" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="635.211" y="333.177284" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="671.717" y="317.237246" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_242">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="525.693" y="293.639978" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="562.199" y="282.90989" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="598.705" y="329.024961" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="635.211" y="320.712834" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="671.717" y="313.339696" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_21">
+    <path d="M 531.777333 313.994378 
+L 531.777333 301.941035 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 568.283333 321.330644 
+L 568.283333 310.197132 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 604.789333 327.478365 
+L 604.789333 320.881881 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 641.295333 320.493286 
+L 641.295333 315.023777 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 677.801333 317.286607 
+L 677.801333 314.772156 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_243">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="531.777333" y="313.994378" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="568.283333" y="321.330644" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="604.789333" y="327.478365" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="641.295333" y="320.493286" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="677.801333" y="317.286607" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_244">
+    <g clip-path="url(#p68a42ee260)">
+     <use xlink:href="#mcb9dfefa88" x="531.777333" y="301.941035" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="568.283333" y="310.197132" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="604.789333" y="320.881881" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="641.295333" y="315.023777" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="677.801333" y="314.772156" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_245">
+    <path d="M 507.44 306.424688 
+L 689.97 306.424688 
+" clip-path="url(#p68a42ee260)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_138">
+    <path d="M 507.44 360.570971 
+L 507.44 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_139">
+    <path d="M 689.97 360.570971 
+L 689.97 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_140">
+    <path d="M 507.44 360.570971 
+L 689.97 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_141">
+    <path d="M 507.44 244.150485 
+L 689.97 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_8">
+   <g id="patch_142">
+    <path d="M 723.47 360.570971 
+L 906 360.570971 
+L 906 244.150485 
+L 723.47 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_15">
+    <g id="xtick_36">
+     <g id="line2d_246">
+      <path d="M 741.723 360.570971 
+L 741.723 244.150485 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_247">
+      <g>
+       <use xlink:href="#m17097843b9" x="741.723" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 4 KiB -->
+      <g transform="translate(728.896746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_248">
+      <path d="M 778.229 360.570971 
+L 778.229 244.150485 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_249">
+      <g>
+       <use xlink:href="#m17097843b9" x="778.229" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 32 KiB -->
+      <g transform="translate(760.903779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_250">
+      <path d="M 814.735 360.570971 
+L 814.735 244.150485 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_251">
+      <g>
+       <use xlink:href="#m17097843b9" x="814.735" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 256 KiB -->
+      <g transform="translate(792.910812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_252">
+      <path d="M 851.241 360.570971 
+L 851.241 244.150485 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_253">
+      <g>
+       <use xlink:href="#m17097843b9" x="851.241" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 1 MiB -->
+      <g transform="translate(836.950814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_254">
+      <path d="M 887.747 360.570971 
+L 887.747 244.150485 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_255">
+      <g>
+       <use xlink:href="#m17097843b9" x="887.747" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 16 MiB -->
+      <g transform="translate(868.957847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_16">
+    <g id="ytick_64">
+     <g id="line2d_256">
+      <path d="M 723.47 358.19322 
+L 906 358.19322 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_257">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="358.19322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_65">
+     <g id="line2d_258">
+      <path d="M 723.47 332.308954 
+L 906 332.308954 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_259">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="332.308954" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_66">
+     <g id="line2d_260">
+      <path d="M 723.47 306.424688 
+L 906 306.424688 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_261">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="306.424688" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_67">
+     <g id="line2d_262">
+      <path d="M 723.47 280.540422 
+L 906 280.540422 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_263">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="280.540422" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_68">
+     <g id="line2d_264">
+      <path d="M 723.47 254.656156 
+L 906 254.656156 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_265">
+      <g>
+       <use xlink:href="#m5f53fe7359" x="723.47" y="254.656156" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_69">
+     <g id="line2d_266">
+      <path d="M 723.47 345.251087 
+L 906 345.251087 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_267">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="345.251087" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_70">
+     <g id="line2d_268">
+      <path d="M 723.47 319.366821 
+L 906 319.366821 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_269">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="319.366821" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_71">
+     <g id="line2d_270">
+      <path d="M 723.47 293.482555 
+L 906 293.482555 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_271">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="293.482555" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_72">
+     <g id="line2d_272">
+      <path d="M 723.47 267.598289 
+L 906 267.598289 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_273">
+      <g>
+       <use xlink:href="#md3ecc308ca" x="723.47" y="267.598289" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_143">
+    <path d="M 732.5965 306.424688 
+L 738.680833 306.424688 
+L 738.680833 311.343218 
+L 732.5965 311.343218 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_144">
+    <path d="M 769.1025 306.424688 
+L 775.186833 306.424688 
+L 775.186833 328.046327 
+L 769.1025 328.046327 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_145">
+    <path d="M 805.6085 306.424688 
+L 811.692833 306.424688 
+L 811.692833 326.042742 
+L 805.6085 326.042742 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_146">
+    <path d="M 842.1145 306.424688 
+L 848.198833 306.424688 
+L 848.198833 319.747913 
+L 842.1145 319.747913 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_147">
+    <path d="M 878.6205 306.424688 
+L 884.704833 306.424688 
+L 884.704833 317.269679 
+L 878.6205 317.269679 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_148">
+    <path d="M 738.680833 306.424688 
+L 744.765167 306.424688 
+L 744.765167 305.701913 
+L 738.680833 305.701913 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_149">
+    <path d="M 775.186833 306.424688 
+L 781.271167 306.424688 
+L 781.271167 330.504116 
+L 775.186833 330.504116 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_150">
+    <path d="M 811.692833 306.424688 
+L 817.777167 306.424688 
+L 817.777167 327.507857 
+L 811.692833 327.507857 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_151">
+    <path d="M 848.198833 306.424688 
+L 854.283167 306.424688 
+L 854.283167 322.057097 
+L 848.198833 322.057097 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_152">
+    <path d="M 884.704833 306.424688 
+L 890.789167 306.424688 
+L 890.789167 316.857886 
+L 884.704833 316.857886 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_153">
+    <path d="M 744.765167 306.424688 
+L 750.8495 306.424688 
+L 750.8495 309.747795 
+L 744.765167 309.747795 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_154">
+    <path d="M 781.271167 306.424688 
+L 787.3555 306.424688 
+L 787.3555 324.487153 
+L 781.271167 324.487153 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_155">
+    <path d="M 817.777167 306.424688 
+L 823.8615 306.424688 
+L 823.8615 320.135331 
+L 817.777167 320.135331 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_156">
+    <path d="M 854.283167 306.424688 
+L 860.3675 306.424688 
+L 860.3675 320.56671 
+L 854.283167 320.56671 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_157">
+    <path d="M 890.789167 306.424688 
+L 896.8735 306.424688 
+L 896.8735 316.805762 
+L 890.789167 316.805762 
+z
+" clip-path="url(#p83c871bcb8)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_22">
+    <path d="M 735.638667 316.306084 
+L 735.638667 306.380351 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 772.144667 330.51558 
+L 772.144667 325.577074 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 808.650667 327.683046 
+L 808.650667 324.402438 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 845.156667 321.126069 
+L 845.156667 318.369756 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 881.662667 318.599306 
+L 881.662667 315.940053 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_274">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="735.638667" y="316.306084" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="772.144667" y="330.51558" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="808.650667" y="327.683046" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="845.156667" y="321.126069" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="881.662667" y="318.599306" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_275">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="735.638667" y="306.380351" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="772.144667" y="325.577074" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="808.650667" y="324.402438" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="845.156667" y="318.369756" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="881.662667" y="315.940053" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_23">
+    <path d="M 741.723 312.563995 
+L 741.723 298.839831 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 778.229 355.279131 
+L 778.229 305.729101 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 814.735 330.91741 
+L 814.735 324.098304 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 851.241 323.711875 
+L 851.241 320.402319 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 887.747 318.695893 
+L 887.747 315.019879 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_276">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="741.723" y="312.563995" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="778.229" y="355.279131" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="814.735" y="330.91741" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="851.241" y="323.711875" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="887.747" y="318.695893" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_277">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="741.723" y="298.839831" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="778.229" y="305.729101" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="814.735" y="324.098304" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="851.241" y="320.402319" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="887.747" y="315.019879" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_24">
+    <path d="M 747.807333 315.746026 
+L 747.807333 303.749564 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 784.313333 326.743101 
+L 784.313333 322.231205 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 820.819333 321.334801 
+L 820.819333 318.935861 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 857.325333 324.136261 
+L 857.325333 316.997158 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 893.831333 318.136408 
+L 893.831333 315.475115 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_278">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="747.807333" y="315.746026" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="784.313333" y="326.743101" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="820.819333" y="321.334801" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="857.325333" y="324.136261" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="893.831333" y="318.136408" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_279">
+    <g clip-path="url(#p83c871bcb8)">
+     <use xlink:href="#mcb9dfefa88" x="747.807333" y="303.749564" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="784.313333" y="322.231205" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="820.819333" y="318.935861" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="857.325333" y="316.997158" style="stroke: #000000"/>
+     <use xlink:href="#mcb9dfefa88" x="893.831333" y="315.475115" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_280">
+    <path d="M 723.47 306.424688 
+L 906 306.424688 
+" clip-path="url(#p83c871bcb8)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_158">
+    <path d="M 723.47 360.570971 
+L 723.47 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_159">
+    <path d="M 906 360.570971 
+L 906 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_160">
+    <path d="M 723.47 360.570971 
+L 906 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_161">
+    <path d="M 723.47 244.150485 
+L 906 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_37">
+   <!-- Null Blk Throughput, $\frac{R-C}{C}$ (Bare Metal) -->
+   <g transform="translate(353.7 20.28) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-43" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(0 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(74.804688 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(138.183594 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(165.966797 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(193.75 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(225.537109 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(294.140625 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(321.923828 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(379.833984 0.254687)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(411.621094 0.254687)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(472.705078 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(536.083984 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(577.197266 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(638.378906 0.254687)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(701.757812 0.254687)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(765.234375 0.254687)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(828.613281 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(892.089844 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(955.46875 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(994.677734 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1026.464844 0.254687)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1058.251953 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-2212" transform="translate(1120.527344 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(1192.817383 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(1125.251953 -39.151563) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1254.194336 0.254687)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1285.981445 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(1324.995117 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1393.598633 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1454.87793 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1495.991211 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1557.514648 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(1589.301758 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1675.581055 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1737.104492 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1776.313477 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1837.592773 0.254687)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(1865.375977 0.254687)"/>
+    <path d="M 1058.251953 19.051563 
+L 1058.251953 25.301563 
+L 1241.694336 25.301563 
+L 1241.694336 19.051563 
+L 1058.251953 19.051563 
+z
+"/>
+   </g>
+  </g>
+  <g id="text_38">
+   <!-- IO/s Difference Relative -->
+   <g transform="translate(16.958438 274.892187) rotate(-90) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-49"/>
+    <use xlink:href="#DejaVuSans-4f" x="29.492188"/>
+    <use xlink:href="#DejaVuSans-2f" x="108.203125"/>
+    <use xlink:href="#DejaVuSans-73" x="141.894531"/>
+    <use xlink:href="#DejaVuSans-20" x="193.994141"/>
+    <use xlink:href="#DejaVuSans-44" x="225.78125"/>
+    <use xlink:href="#DejaVuSans-69" x="302.783203"/>
+    <use xlink:href="#DejaVuSans-66" x="330.566406"/>
+    <use xlink:href="#DejaVuSans-66" x="365.771484"/>
+    <use xlink:href="#DejaVuSans-65" x="400.976562"/>
+    <use xlink:href="#DejaVuSans-72" x="462.5"/>
+    <use xlink:href="#DejaVuSans-65" x="501.363281"/>
+    <use xlink:href="#DejaVuSans-6e" x="562.886719"/>
+    <use xlink:href="#DejaVuSans-63" x="626.265625"/>
+    <use xlink:href="#DejaVuSans-65" x="681.246094"/>
+    <use xlink:href="#DejaVuSans-20" x="742.769531"/>
+    <use xlink:href="#DejaVuSans-52" x="774.556641"/>
+    <use xlink:href="#DejaVuSans-65" x="839.539062"/>
+    <use xlink:href="#DejaVuSans-6c" x="901.0625"/>
+    <use xlink:href="#DejaVuSans-61" x="928.845703"/>
+    <use xlink:href="#DejaVuSans-74" x="990.125"/>
+    <use xlink:href="#DejaVuSans-69" x="1029.333984"/>
+    <use xlink:href="#DejaVuSans-76" x="1057.117188"/>
+    <use xlink:href="#DejaVuSans-65" x="1116.296875"/>
+   </g>
+  </g>
+  <g id="text_39">
+   <!-- Block Size (KiB) -->
+   <g transform="translate(429.034375 427.68) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-42"/>
+    <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+    <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+    <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+    <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+    <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+    <use xlink:href="#DejaVuSans-53" x="302.246094"/>
+    <use xlink:href="#DejaVuSans-69" x="365.722656"/>
+    <use xlink:href="#DejaVuSans-7a" x="393.505859"/>
+    <use xlink:href="#DejaVuSans-65" x="445.996094"/>
+    <use xlink:href="#DejaVuSans-20" x="507.519531"/>
+    <use xlink:href="#DejaVuSans-28" x="539.306641"/>
+    <use xlink:href="#DejaVuSans-4b" x="578.320312"/>
+    <use xlink:href="#DejaVuSans-69" x="643.896484"/>
+    <use xlink:href="#DejaVuSans-42" x="671.679688"/>
+    <use xlink:href="#DejaVuSans-29" x="740.283203"/>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="patch_162">
+    <path d="M 35.08 59.8 
+L 182.1675 59.8 
+Q 184.1675 59.8 184.1675 57.8 
+L 184.1675 29.44375 
+Q 184.1675 27.44375 182.1675 27.44375 
+L 35.08 27.44375 
+Q 33.08 27.44375 33.08 29.44375 
+L 33.08 57.8 
+Q 33.08 59.8 35.08 59.8 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_40">
+    <!-- Threads (cores) -->
+    <g transform="translate(69.615156 39.042188) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-72" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-65" x="163.326172"/>
+     <use xlink:href="#DejaVuSans-61" x="224.849609"/>
+     <use xlink:href="#DejaVuSans-64" x="286.128906"/>
+     <use xlink:href="#DejaVuSans-73" x="349.605469"/>
+     <use xlink:href="#DejaVuSans-20" x="401.705078"/>
+     <use xlink:href="#DejaVuSans-28" x="433.492188"/>
+     <use xlink:href="#DejaVuSans-63" x="472.505859"/>
+     <use xlink:href="#DejaVuSans-6f" x="527.486328"/>
+     <use xlink:href="#DejaVuSans-72" x="588.667969"/>
+     <use xlink:href="#DejaVuSans-65" x="627.53125"/>
+     <use xlink:href="#DejaVuSans-73" x="689.054688"/>
+     <use xlink:href="#DejaVuSans-29" x="741.154297"/>
+    </g>
+   </g>
+   <g id="patch_163">
+    <path d="M 37.08 53.720313 
+L 57.08 53.720313 
+L 57.08 46.720313 
+L 37.08 46.720313 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_41">
+    <!-- 1 -->
+    <g transform="translate(65.08 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="patch_164">
+    <path d="M 91.4425 53.720313 
+L 111.4425 53.720313 
+L 111.4425 46.720313 
+L 91.4425 46.720313 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_42">
+    <!-- 2 -->
+    <g transform="translate(119.4425 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+    </g>
+   </g>
+   <g id="patch_165">
+    <path d="M 145.805 53.720313 
+L 165.805 53.720313 
+L 165.805 46.720313 
+L 145.805 46.720313 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_43">
+    <!-- 6 -->
+    <g transform="translate(173.805 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p0e557f1406">
+   <rect x="75.38" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="pce634f8ef5">
+   <rect x="291.41" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p124370f7f8">
+   <rect x="507.44" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p8fcfa6f282">
+   <rect x="723.47" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p3be495d188">
+   <rect x="75.38" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p9c1e6e133a">
+   <rect x="291.41" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p68a42ee260">
+   <rect x="507.44" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p83c871bcb8">
+   <rect x="723.47" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/rnull/rnull-v6.12-rc2.svg
+++ b/src/rnull/rnull-v6.12-rc2.svg
@@ -1,0 +1,4930 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="936pt" height="432pt" viewBox="0 0 936 432" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432 
+L 936 432 
+L 936 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 75.38 210.650485 
+L 257.91 210.650485 
+L 257.91 94.23 
+L 75.38 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 93.633 210.650485 
+L 93.633 94.23 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="madba55393a" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#madba55393a" x="93.633" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 130.139 210.650485 
+L 130.139 94.23 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#madba55393a" x="130.139" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 166.645 210.650485 
+L 166.645 94.23 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#madba55393a" x="166.645" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 203.151 210.650485 
+L 203.151 94.23 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#madba55393a" x="203.151" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 239.657 210.650485 
+L 239.657 94.23 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#madba55393a" x="239.657" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <path d="M 75.38 189.345039 
+L 257.91 189.345039 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <defs>
+       <path id="m682f1ae931" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="189.345039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −0.1 -->
+      <g transform="translate(44.097188 193.144258) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_13">
+      <path d="M 75.38 162.034021 
+L 257.91 162.034021 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="162.034021" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.0 -->
+      <g transform="translate(52.476875 165.83324) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <path d="M 75.38 134.723003 
+L 257.91 134.723003 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="134.723003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.1 -->
+      <g transform="translate(52.476875 138.522221) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_17">
+      <path d="M 75.38 107.411984 
+L 257.91 107.411984 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="107.411984" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.2 -->
+      <g transform="translate(52.476875 111.211203) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_19">
+      <path d="M 75.38 203.000549 
+L 257.91 203.000549 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <defs>
+       <path id="m19397d4597" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="203.000549" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_21">
+      <path d="M 75.38 175.68953 
+L 257.91 175.68953 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="175.68953" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_23">
+      <path d="M 75.38 148.378512 
+L 257.91 148.378512 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="148.378512" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_25">
+      <path d="M 75.38 121.067493 
+L 257.91 121.067493 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="121.067493" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- randread -->
+     <g transform="translate(38.0175 175.160555) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-61" x="41.113281"/>
+      <use xlink:href="#DejaVuSans-6e" x="102.392578"/>
+      <use xlink:href="#DejaVuSans-64" x="165.771484"/>
+      <use xlink:href="#DejaVuSans-72" x="229.248047"/>
+      <use xlink:href="#DejaVuSans-65" x="268.111328"/>
+      <use xlink:href="#DejaVuSans-61" x="329.634766"/>
+      <use xlink:href="#DejaVuSans-64" x="390.914062"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.5065 162.034021 
+L 90.590833 162.034021 
+L 90.590833 157.595274 
+L 84.5065 157.595274 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 121.0125 162.034021 
+L 127.096833 162.034021 
+L 127.096833 121.574235 
+L 121.0125 121.574235 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 157.5185 162.034021 
+L 163.602833 162.034021 
+L 163.602833 148.441643 
+L 157.5185 148.441643 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 194.0245 162.034021 
+L 200.108833 162.034021 
+L 200.108833 151.329983 
+L 194.0245 151.329983 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 230.5305 162.034021 
+L 236.614833 162.034021 
+L 236.614833 186.077972 
+L 230.5305 186.077972 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 90.590833 162.034021 
+L 96.675167 162.034021 
+L 96.675167 156.387989 
+L 90.590833 156.387989 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 127.096833 162.034021 
+L 133.181167 162.034021 
+L 133.181167 162.951861 
+L 127.096833 162.951861 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 163.602833 162.034021 
+L 169.687167 162.034021 
+L 169.687167 174.35255 
+L 163.602833 174.35255 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 200.108833 162.034021 
+L 206.193167 162.034021 
+L 206.193167 179.049506 
+L 200.108833 179.049506 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 236.614833 162.034021 
+L 242.699167 162.034021 
+L 242.699167 176.849853 
+L 236.614833 176.849853 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 96.675167 162.034021 
+L 102.7595 162.034021 
+L 102.7595 158.975612 
+L 96.675167 158.975612 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 133.181167 162.034021 
+L 139.2655 162.034021 
+L 139.2655 168.640117 
+L 133.181167 168.640117 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 169.687167 162.034021 
+L 175.7715 162.034021 
+L 175.7715 169.467415 
+L 169.687167 169.467415 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 206.193167 162.034021 
+L 212.2775 162.034021 
+L 212.2775 181.904095 
+L 206.193167 181.904095 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 242.699167 162.034021 
+L 248.7835 162.034021 
+L 248.7835 178.270146 
+L 242.699167 178.270146 
+z
+" clip-path="url(#pe1a35bceb6)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 87.548667 160.887449 
+L 87.548667 154.303099 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 124.054667 125.089391 
+L 124.054667 118.059079 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 160.560667 157.04625 
+L 160.560667 139.837036 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 197.066667 155.093932 
+L 197.066667 147.566035 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 233.572667 189.155784 
+L 233.572667 183.000159 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_27">
+    <defs>
+     <path id="m5f82a262da" d="M 1.5 0 
+L -1.5 -0 
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="87.548667" y="160.887449" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="124.054667" y="125.089391" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="160.560667" y="157.04625" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="197.066667" y="155.093932" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="233.572667" y="189.155784" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_28">
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="87.548667" y="154.303099" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="124.054667" y="118.059079" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="160.560667" y="139.837036" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="197.066667" y="147.566035" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="233.572667" y="183.000159" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 93.633 164.675219 
+L 93.633 148.100759 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 130.139 176.702522 
+L 130.139 149.201199 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 166.645 184.792653 
+L 166.645 163.912446 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.151 186.46363 
+L 203.151 171.635383 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 239.657 179.883123 
+L 239.657 173.816584 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_29">
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="93.633" y="164.675219" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="130.139" y="176.702522" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="166.645" y="184.792653" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="203.151" y="186.46363" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="239.657" y="179.883123" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_30">
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="93.633" y="148.100759" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="130.139" y="149.201199" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="166.645" y="163.912446" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="203.151" y="171.635383" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="239.657" y="173.816584" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 99.717333 176.808898 
+L 99.717333 141.142327 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 136.223333 178.366976 
+L 136.223333 158.913257 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 172.729333 180.781553 
+L 172.729333 158.153278 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 209.235333 188.597933 
+L 209.235333 175.210256 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.741333 180.269851 
+L 245.741333 176.27044 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_31">
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="99.717333" y="176.808898" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="136.223333" y="178.366976" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="172.729333" y="180.781553" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="209.235333" y="188.597933" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="245.741333" y="180.269851" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_32">
+    <g clip-path="url(#pe1a35bceb6)">
+     <use xlink:href="#m5f82a262da" x="99.717333" y="141.142327" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="136.223333" y="158.913257" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="172.729333" y="158.153278" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="209.235333" y="175.210256" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="245.741333" y="176.27044" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path d="M 75.38 162.034021 
+L 257.91 162.034021 
+" clip-path="url(#pe1a35bceb6)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 75.38 210.650485 
+L 75.38 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 257.91 210.650485 
+L 257.91 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 75.38 210.650485 
+L 257.91 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 75.38 94.23 
+L 257.91 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_6">
+    <!-- qd 1 -->
+    <g transform="translate(153.3025 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-31" x="158.740234"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_22">
+    <path d="M 291.41 210.650485 
+L 473.94 210.650485 
+L 473.94 94.23 
+L 291.41 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_34">
+      <path d="M 309.663 210.650485 
+L 309.663 94.23 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#madba55393a" x="309.663" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_36">
+      <path d="M 346.169 210.650485 
+L 346.169 94.23 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#madba55393a" x="346.169" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_38">
+      <path d="M 382.675 210.650485 
+L 382.675 94.23 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#madba55393a" x="382.675" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_40">
+      <path d="M 419.181 210.650485 
+L 419.181 94.23 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#madba55393a" x="419.181" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_42">
+      <path d="M 455.687 210.650485 
+L 455.687 94.23 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#madba55393a" x="455.687" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_9">
+     <g id="line2d_44">
+      <path d="M 291.41 189.345039 
+L 473.94 189.345039 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="189.345039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_46">
+      <path d="M 291.41 162.034021 
+L 473.94 162.034021 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="162.034021" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_48">
+      <path d="M 291.41 134.723003 
+L 473.94 134.723003 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="134.723003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_50">
+      <path d="M 291.41 107.411984 
+L 473.94 107.411984 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="107.411984" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_52">
+      <path d="M 291.41 203.000549 
+L 473.94 203.000549 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="203.000549" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_54">
+      <path d="M 291.41 175.68953 
+L 473.94 175.68953 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="175.68953" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_56">
+      <path d="M 291.41 148.378512 
+L 473.94 148.378512 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="148.378512" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_58">
+      <path d="M 291.41 121.067493 
+L 473.94 121.067493 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="121.067493" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 300.5365 162.034021 
+L 306.620833 162.034021 
+L 306.620833 157.564734 
+L 300.5365 157.564734 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 337.0425 162.034021 
+L 343.126833 162.034021 
+L 343.126833 112.439594 
+L 337.0425 112.439594 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 373.5485 162.034021 
+L 379.632833 162.034021 
+L 379.632833 128.598602 
+L 373.5485 128.598602 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 410.0545 162.034021 
+L 416.138833 162.034021 
+L 416.138833 169.993865 
+L 410.0545 169.993865 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 446.5605 162.034021 
+L 452.644833 162.034021 
+L 452.644833 158.032583 
+L 446.5605 158.032583 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 306.620833 162.034021 
+L 312.705167 162.034021 
+L 312.705167 161.762888 
+L 306.620833 161.762888 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 343.126833 162.034021 
+L 349.211167 162.034021 
+L 349.211167 145.88992 
+L 343.126833 145.88992 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 379.632833 162.034021 
+L 385.717167 162.034021 
+L 385.717167 119.427613 
+L 379.632833 119.427613 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 416.138833 162.034021 
+L 422.223167 162.034021 
+L 422.223167 178.908538 
+L 416.138833 178.908538 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 452.644833 162.034021 
+L 458.729167 162.034021 
+L 458.729167 168.080372 
+L 452.644833 168.080372 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 312.705167 162.034021 
+L 318.7895 162.034021 
+L 318.7895 160.84554 
+L 312.705167 160.84554 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 349.211167 162.034021 
+L 355.2955 162.034021 
+L 355.2955 151.421128 
+L 349.211167 151.421128 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 385.717167 162.034021 
+L 391.8015 162.034021 
+L 391.8015 121.407603 
+L 385.717167 121.407603 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 422.223167 162.034021 
+L 428.3075 162.034021 
+L 428.3075 181.668761 
+L 422.223167 181.668761 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 458.729167 162.034021 
+L 464.8135 162.034021 
+L 464.8135 168.795548 
+L 458.729167 168.795548 
+z
+" clip-path="url(#p67b5e85c1d)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 303.578667 160.181902 
+L 303.578667 154.947566 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 340.084667 117.332283 
+L 340.084667 107.546905 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 376.590667 133.126602 
+L 376.590667 124.070601 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 413.096667 173.00299 
+L 413.096667 166.984741 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 449.602667 162.959942 
+L 449.602667 153.105225 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_60">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="303.578667" y="160.181902" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="340.084667" y="117.332283" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="376.590667" y="133.126602" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="413.096667" y="173.00299" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="449.602667" y="162.959942" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_61">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="303.578667" y="154.947566" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="340.084667" y="107.546905" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="376.590667" y="124.070601" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="413.096667" y="166.984741" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="449.602667" y="153.105225" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_5">
+    <path d="M 309.663 171.319364 
+L 309.663 152.206412 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 346.169 160.577748 
+L 346.169 131.202091 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 382.675 124.249449 
+L 382.675 114.605778 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 419.181 183.084061 
+L 419.181 174.733014 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 455.687 169.79256 
+L 455.687 166.368185 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_62">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="309.663" y="171.319364" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="346.169" y="160.577748" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="382.675" y="124.249449" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="419.181" y="183.084061" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="455.687" y="169.79256" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_63">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="309.663" y="152.206412" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="346.169" y="131.202091" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="382.675" y="114.605778" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="419.181" y="174.733014" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="455.687" y="166.368185" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_6">
+    <path d="M 315.747333 178.388316 
+L 315.747333 143.302765 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 352.253333 164.637557 
+L 352.253333 138.2047 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 388.759333 129.407073 
+L 388.759333 113.408134 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 425.265333 183.346 
+L 425.265333 179.991522 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 461.771333 170.090839 
+L 461.771333 167.500257 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_64">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="315.747333" y="178.388316" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="352.253333" y="164.637557" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="388.759333" y="129.407073" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="425.265333" y="183.346" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="461.771333" y="170.090839" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_65">
+    <g clip-path="url(#p67b5e85c1d)">
+     <use xlink:href="#m5f82a262da" x="315.747333" y="143.302765" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="352.253333" y="138.2047" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="388.759333" y="113.408134" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="425.265333" y="179.991522" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="461.771333" y="167.500257" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_66">
+    <path d="M 291.41 162.034021 
+L 473.94 162.034021 
+" clip-path="url(#p67b5e85c1d)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 291.41 210.650485 
+L 291.41 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 473.94 210.650485 
+L 473.94 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 291.41 210.650485 
+L 473.94 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 291.41 94.23 
+L 473.94 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <!-- qd 8 -->
+    <g transform="translate(369.3325 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-38" x="158.740234"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_42">
+    <path d="M 507.44 210.650485 
+L 689.97 210.650485 
+L 689.97 94.23 
+L 507.44 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_11">
+     <g id="line2d_67">
+      <path d="M 525.693 210.650485 
+L 525.693 94.23 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#madba55393a" x="525.693" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_69">
+      <path d="M 562.199 210.650485 
+L 562.199 94.23 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#madba55393a" x="562.199" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_71">
+      <path d="M 598.705 210.650485 
+L 598.705 94.23 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#madba55393a" x="598.705" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_73">
+      <path d="M 635.211 210.650485 
+L 635.211 94.23 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#madba55393a" x="635.211" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_75">
+      <path d="M 671.717 210.650485 
+L 671.717 94.23 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#madba55393a" x="671.717" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_17">
+     <g id="line2d_77">
+      <path d="M 507.44 189.345039 
+L 689.97 189.345039 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="189.345039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_79">
+      <path d="M 507.44 162.034021 
+L 689.97 162.034021 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="162.034021" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_81">
+      <path d="M 507.44 134.723003 
+L 689.97 134.723003 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="134.723003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_83">
+      <path d="M 507.44 107.411984 
+L 689.97 107.411984 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="107.411984" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_85">
+      <path d="M 507.44 203.000549 
+L 689.97 203.000549 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="203.000549" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_87">
+      <path d="M 507.44 175.68953 
+L 689.97 175.68953 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="175.68953" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_89">
+      <path d="M 507.44 148.378512 
+L 689.97 148.378512 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="148.378512" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_91">
+      <path d="M 507.44 121.067493 
+L 689.97 121.067493 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="121.067493" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_43">
+    <path d="M 516.5665 162.034021 
+L 522.650833 162.034021 
+L 522.650833 157.310017 
+L 516.5665 157.310017 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 553.0725 162.034021 
+L 559.156833 162.034021 
+L 559.156833 109.243728 
+L 553.0725 109.243728 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 589.5785 162.034021 
+L 595.662833 162.034021 
+L 595.662833 131.016686 
+L 589.5785 131.016686 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 626.0845 162.034021 
+L 632.168833 162.034021 
+L 632.168833 177.945841 
+L 626.0845 177.945841 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 662.5905 162.034021 
+L 668.674833 162.034021 
+L 668.674833 167.186325 
+L 662.5905 167.186325 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 522.650833 162.034021 
+L 528.735167 162.034021 
+L 528.735167 151.938639 
+L 522.650833 151.938639 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 559.156833 162.034021 
+L 565.241167 162.034021 
+L 565.241167 160.845444 
+L 559.156833 160.845444 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 595.662833 162.034021 
+L 601.747167 162.034021 
+L 601.747167 134.925594 
+L 595.662833 134.925594 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 632.168833 162.034021 
+L 638.253167 162.034021 
+L 638.253167 176.226321 
+L 632.168833 176.226321 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 668.674833 162.034021 
+L 674.759167 162.034021 
+L 674.759167 167.622497 
+L 668.674833 167.622497 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 528.735167 162.034021 
+L 534.8195 162.034021 
+L 534.8195 159.796981 
+L 528.735167 159.796981 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 565.241167 162.034021 
+L 571.3255 162.034021 
+L 571.3255 165.5408 
+L 565.241167 165.5408 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 601.747167 162.034021 
+L 607.8315 162.034021 
+L 607.8315 178.039222 
+L 601.747167 178.039222 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 638.253167 162.034021 
+L 644.3375 162.034021 
+L 644.3375 170.694074 
+L 638.253167 170.694074 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 674.759167 162.034021 
+L 680.8435 162.034021 
+L 680.8435 168.808493 
+L 674.759167 168.808493 
+z
+" clip-path="url(#p31bf26b7ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_7">
+    <path d="M 519.608667 160.509258 
+L 519.608667 154.110775 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 556.114667 112.78829 
+L 556.114667 105.699166 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 592.620667 135.152321 
+L 592.620667 126.881051 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 629.126667 180.824953 
+L 629.126667 175.066729 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 665.632667 168.404481 
+L 665.632667 165.968169 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_93">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="519.608667" y="160.509258" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="556.114667" y="112.78829" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="592.620667" y="135.152321" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="629.126667" y="180.824953" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="665.632667" y="168.404481" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_94">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="519.608667" y="154.110775" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="556.114667" y="105.699166" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="592.620667" y="126.881051" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="629.126667" y="175.066729" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="665.632667" y="165.968169" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_8">
+    <path d="M 525.693 162.332576 
+L 525.693 141.544701 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 562.199 178.861196 
+L 562.199 142.829693 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 598.705 141.277345 
+L 598.705 128.573844 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 635.211 177.905077 
+L 635.211 174.547566 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 671.717 168.806358 
+L 671.717 166.438635 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_95">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="525.693" y="162.332576" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="562.199" y="178.861196" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="598.705" y="141.277345" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="635.211" y="177.905077" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="671.717" y="168.806358" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_96">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="525.693" y="141.544701" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="562.199" y="142.829693" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="598.705" y="128.573844" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="635.211" y="174.547566" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="671.717" y="166.438635" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_9">
+    <path d="M 531.777333 177.914693 
+L 531.777333 141.679269 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 568.283333 177.832338 
+L 568.283333 153.249262 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 604.789333 179.422019 
+L 604.789333 176.656425 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 641.295333 172.851085 
+L 641.295333 168.537063 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 677.801333 170.014611 
+L 677.801333 167.602375 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_97">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="531.777333" y="177.914693" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="568.283333" y="177.832338" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="604.789333" y="179.422019" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="641.295333" y="172.851085" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="677.801333" y="170.014611" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_98">
+    <g clip-path="url(#p31bf26b7ad)">
+     <use xlink:href="#m5f82a262da" x="531.777333" y="141.679269" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="568.283333" y="153.249262" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="604.789333" y="176.656425" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="641.295333" y="168.537063" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="677.801333" y="167.602375" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_99">
+    <path d="M 507.44 162.034021 
+L 689.97 162.034021 
+" clip-path="url(#p31bf26b7ad)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 507.44 210.650485 
+L 507.44 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 689.97 210.650485 
+L 689.97 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 507.44 210.650485 
+L 689.97 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 507.44 94.23 
+L 689.97 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_8">
+    <!-- qd 32 -->
+    <g transform="translate(581.545 88.23) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-33" x="158.740234"/>
+     <use xlink:href="#DejaVuSans-32" x="222.363281"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_62">
+    <path d="M 723.47 210.650485 
+L 906 210.650485 
+L 906 94.23 
+L 723.47 94.23 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_16">
+     <g id="line2d_100">
+      <path d="M 741.723 210.650485 
+L 741.723 94.23 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#madba55393a" x="741.723" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_102">
+      <path d="M 778.229 210.650485 
+L 778.229 94.23 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#madba55393a" x="778.229" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_104">
+      <path d="M 814.735 210.650485 
+L 814.735 94.23 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#madba55393a" x="814.735" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_106">
+      <path d="M 851.241 210.650485 
+L 851.241 94.23 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#madba55393a" x="851.241" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_108">
+      <path d="M 887.747 210.650485 
+L 887.747 94.23 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#madba55393a" x="887.747" y="210.650485" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_25">
+     <g id="line2d_110">
+      <path d="M 723.47 189.345039 
+L 906 189.345039 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="189.345039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_112">
+      <path d="M 723.47 162.034021 
+L 906 162.034021 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="162.034021" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_114">
+      <path d="M 723.47 134.723003 
+L 906 134.723003 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="134.723003" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_116">
+      <path d="M 723.47 107.411984 
+L 906 107.411984 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="107.411984" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_118">
+      <path d="M 723.47 203.000549 
+L 906 203.000549 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_119">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="203.000549" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_120">
+      <path d="M 723.47 175.68953 
+L 906 175.68953 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_121">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="175.68953" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_122">
+      <path d="M 723.47 148.378512 
+L 906 148.378512 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_123">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="148.378512" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_124">
+      <path d="M 723.47 121.067493 
+L 906 121.067493 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_125">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="121.067493" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_63">
+    <path d="M 732.5965 162.034021 
+L 738.680833 162.034021 
+L 738.680833 170.021527 
+L 732.5965 170.021527 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 769.1025 162.034021 
+L 775.186833 162.034021 
+L 775.186833 103.191252 
+L 769.1025 103.191252 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 805.6085 162.034021 
+L 811.692833 162.034021 
+L 811.692833 184.61219 
+L 805.6085 184.61219 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 842.1145 162.034021 
+L 848.198833 162.034021 
+L 848.198833 156.817588 
+L 842.1145 156.817588 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 878.6205 162.034021 
+L 884.704833 162.034021 
+L 884.704833 167.379639 
+L 878.6205 167.379639 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_68">
+    <path d="M 738.680833 162.034021 
+L 744.765167 162.034021 
+L 744.765167 186.640805 
+L 738.680833 186.640805 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_69">
+    <path d="M 775.186833 162.034021 
+L 781.271167 162.034021 
+L 781.271167 139.323396 
+L 775.186833 139.323396 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_70">
+    <path d="M 811.692833 162.034021 
+L 817.777167 162.034021 
+L 817.777167 173.714849 
+L 811.692833 173.714849 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_71">
+    <path d="M 848.198833 162.034021 
+L 854.283167 162.034021 
+L 854.283167 169.468981 
+L 848.198833 169.468981 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_72">
+    <path d="M 884.704833 162.034021 
+L 890.789167 162.034021 
+L 890.789167 168.077622 
+L 884.704833 168.077622 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_73">
+    <path d="M 744.765167 162.034021 
+L 750.8495 162.034021 
+L 750.8495 184.418728 
+L 744.765167 184.418728 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_74">
+    <path d="M 781.271167 162.034021 
+L 787.3555 162.034021 
+L 787.3555 143.730989 
+L 781.271167 143.730989 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_75">
+    <path d="M 817.777167 162.034021 
+L 823.8615 162.034021 
+L 823.8615 174.989841 
+L 817.777167 174.989841 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_76">
+    <path d="M 854.283167 162.034021 
+L 860.3675 162.034021 
+L 860.3675 170.556866 
+L 854.283167 170.556866 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_77">
+    <path d="M 890.789167 162.034021 
+L 896.8735 162.034021 
+L 896.8735 169.056029 
+L 890.789167 169.056029 
+z
+" clip-path="url(#p8bd39972ad)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_10">
+    <path d="M 735.638667 176.878973 
+L 735.638667 163.164081 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 772.144667 106.860664 
+L 772.144667 99.52184 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 808.650667 187.153982 
+L 808.650667 182.070398 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 845.156667 161.820412 
+L 845.156667 151.814764 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 881.662667 168.543463 
+L 881.662667 166.215815 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_126">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="735.638667" y="176.878973" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="772.144667" y="106.860664" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="808.650667" y="187.153982" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="845.156667" y="161.820412" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="881.662667" y="168.543463" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_127">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="735.638667" y="163.164081" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="772.144667" y="99.52184" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="808.650667" y="182.070398" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="845.156667" y="151.814764" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="881.662667" y="166.215815" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_11">
+    <path d="M 741.723 199.006421 
+L 741.723 174.275189 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 778.229 154.922292 
+L 778.229 123.7245 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 814.735 175.091635 
+L 814.735 172.338063 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 851.241 171.063199 
+L 851.241 167.874764 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 887.747 169.232226 
+L 887.747 166.923017 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_128">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="741.723" y="199.006421" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="778.229" y="154.922292" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="814.735" y="175.091635" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="851.241" y="171.063199" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="887.747" y="169.232226" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_129">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="741.723" y="174.275189" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="778.229" y="123.7245" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="814.735" y="172.338063" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="851.241" y="167.874764" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="887.747" y="166.923017" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_12">
+    <path d="M 747.807333 196.434501 
+L 747.807333 172.402954 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 784.313333 149.78054 
+L 784.313333 137.681438 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 820.819333 177.696225 
+L 820.819333 172.283456 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 857.325333 172.941418 
+L 857.325333 168.172314 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 893.831333 170.30927 
+L 893.831333 167.802788 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_130">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="747.807333" y="196.434501" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="784.313333" y="149.78054" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="820.819333" y="177.696225" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="857.325333" y="172.941418" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="893.831333" y="170.30927" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_131">
+    <g clip-path="url(#p8bd39972ad)">
+     <use xlink:href="#m5f82a262da" x="747.807333" y="172.402954" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="784.313333" y="137.681438" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="820.819333" y="172.283456" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="857.325333" y="168.172314" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="893.831333" y="167.802788" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_132">
+    <path d="M 723.47 162.034021 
+L 906 162.034021 
+" clip-path="url(#p8bd39972ad)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_78">
+    <path d="M 723.47 210.650485 
+L 723.47 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_79">
+    <path d="M 906 210.650485 
+L 906 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_80">
+    <path d="M 723.47 210.650485 
+L 906 210.650485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_81">
+    <path d="M 723.47 94.23 
+L 906 94.23 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_9">
+    <!-- qd 128 -->
+    <g transform="translate(793.7575 88.23) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-71"/>
+     <use xlink:href="#DejaVuSans-64" x="63.476562"/>
+     <use xlink:href="#DejaVuSans-20" x="126.953125"/>
+     <use xlink:href="#DejaVuSans-31" x="158.740234"/>
+     <use xlink:href="#DejaVuSans-32" x="222.363281"/>
+     <use xlink:href="#DejaVuSans-38" x="285.986328"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_82">
+    <path d="M 75.38 360.570971 
+L 257.91 360.570971 
+L 257.91 244.150485 
+L 75.38 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_21">
+     <g id="line2d_133">
+      <path d="M 93.633 360.570971 
+L 93.633 244.150485 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_134">
+      <g>
+       <use xlink:href="#madba55393a" x="93.633" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4 KiB -->
+      <g transform="translate(80.806746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_135">
+      <path d="M 130.139 360.570971 
+L 130.139 244.150485 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_136">
+      <g>
+       <use xlink:href="#madba55393a" x="130.139" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 32 KiB -->
+      <g transform="translate(112.813779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_137">
+      <path d="M 166.645 360.570971 
+L 166.645 244.150485 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_138">
+      <g>
+       <use xlink:href="#madba55393a" x="166.645" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 256 KiB -->
+      <g transform="translate(144.820812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_139">
+      <path d="M 203.151 360.570971 
+L 203.151 244.150485 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_140">
+      <g>
+       <use xlink:href="#madba55393a" x="203.151" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1 MiB -->
+      <g transform="translate(188.860814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_141">
+      <path d="M 239.657 360.570971 
+L 239.657 244.150485 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#madba55393a" x="239.657" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 16 MiB -->
+      <g transform="translate(220.867847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10">
+    <g id="ytick_33">
+     <g id="line2d_143">
+      <path d="M 75.38 339.265525 
+L 257.91 339.265525 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="339.265525" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- −0.1 -->
+      <g transform="translate(44.097188 343.064744) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_145">
+      <path d="M 75.38 311.954506 
+L 257.91 311.954506 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="311.954506" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.0 -->
+      <g transform="translate(52.476875 315.753725) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_147">
+      <path d="M 75.38 284.643488 
+L 257.91 284.643488 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="284.643488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.1 -->
+      <g transform="translate(52.476875 288.442707) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_149">
+      <path d="M 75.38 257.33247 
+L 257.91 257.33247 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m682f1ae931" x="75.38" y="257.33247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0.2 -->
+      <g transform="translate(52.476875 261.131688) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_151">
+      <path d="M 75.38 352.921034 
+L 257.91 352.921034 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="352.921034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_153">
+      <path d="M 75.38 325.610016 
+L 257.91 325.610016 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="325.610016" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_155">
+      <path d="M 75.38 298.298997 
+L 257.91 298.298997 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="298.298997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_157">
+      <path d="M 75.38 270.987979 
+L 257.91 270.987979 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m19397d4597" x="75.38" y="270.987979" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- randwrite -->
+     <g transform="translate(38.0175 326.393541) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-72"/>
+      <use xlink:href="#DejaVuSans-61" x="41.113281"/>
+      <use xlink:href="#DejaVuSans-6e" x="102.392578"/>
+      <use xlink:href="#DejaVuSans-64" x="165.771484"/>
+      <use xlink:href="#DejaVuSans-77" x="229.248047"/>
+      <use xlink:href="#DejaVuSans-72" x="311.035156"/>
+      <use xlink:href="#DejaVuSans-69" x="352.148438"/>
+      <use xlink:href="#DejaVuSans-74" x="379.931641"/>
+      <use xlink:href="#DejaVuSans-65" x="419.140625"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_83">
+    <path d="M 84.5065 311.954506 
+L 90.590833 311.954506 
+L 90.590833 329.55415 
+L 84.5065 329.55415 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_84">
+    <path d="M 121.0125 311.954506 
+L 127.096833 311.954506 
+L 127.096833 326.512353 
+L 121.0125 326.512353 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_85">
+    <path d="M 157.5185 311.954506 
+L 163.602833 311.954506 
+L 163.602833 333.043462 
+L 157.5185 333.043462 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_86">
+    <path d="M 194.0245 311.954506 
+L 200.108833 311.954506 
+L 200.108833 326.629153 
+L 194.0245 326.629153 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_87">
+    <path d="M 230.5305 311.954506 
+L 236.614833 311.954506 
+L 236.614833 335.492864 
+L 230.5305 335.492864 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_88">
+    <path d="M 90.590833 311.954506 
+L 96.675167 311.954506 
+L 96.675167 322.265072 
+L 90.590833 322.265072 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_89">
+    <path d="M 127.096833 311.954506 
+L 133.181167 311.954506 
+L 133.181167 329.10668 
+L 127.096833 329.10668 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_90">
+    <path d="M 163.602833 311.954506 
+L 169.687167 311.954506 
+L 169.687167 332.008746 
+L 163.602833 332.008746 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_91">
+    <path d="M 200.108833 311.954506 
+L 206.193167 311.954506 
+L 206.193167 324.951417 
+L 200.108833 324.951417 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_92">
+    <path d="M 236.614833 311.954506 
+L 242.699167 311.954506 
+L 242.699167 334.741699 
+L 236.614833 334.741699 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_93">
+    <path d="M 96.675167 311.954506 
+L 102.7595 311.954506 
+L 102.7595 326.850591 
+L 96.675167 326.850591 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_94">
+    <path d="M 133.181167 311.954506 
+L 139.2655 311.954506 
+L 139.2655 317.965014 
+L 133.181167 317.965014 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_95">
+    <path d="M 169.687167 311.954506 
+L 175.7715 311.954506 
+L 175.7715 330.082305 
+L 169.687167 330.082305 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_96">
+    <path d="M 206.193167 311.954506 
+L 212.2775 311.954506 
+L 212.2775 326.013563 
+L 206.193167 326.013563 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_97">
+    <path d="M 242.699167 311.954506 
+L 248.7835 311.954506 
+L 248.7835 321.751944 
+L 242.699167 321.751944 
+z
+" clip-path="url(#pdec16a7099)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_13">
+    <path d="M 87.548667 333.230242 
+L 87.548667 325.878057 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 124.054667 329.355251 
+L 124.054667 323.669455 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 160.560667 335.808682 
+L 160.560667 330.278242 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 197.066667 330.50227 
+L 197.066667 322.756037 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 233.572667 338.127156 
+L 233.572667 332.858573 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_159">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="87.548667" y="333.230242" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="124.054667" y="329.355251" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="160.560667" y="335.808682" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="197.066667" y="330.50227" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="233.572667" y="338.127156" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_160">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="87.548667" y="325.878057" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="124.054667" y="323.669455" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="160.560667" y="330.278242" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="197.066667" y="322.756037" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="233.572667" y="332.858573" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_14">
+    <path d="M 93.633 328.329643 
+L 93.633 316.200501 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 130.139 355.279131 
+L 130.139 302.934229 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 166.645 334.225954 
+L 166.645 329.791538 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.151 327.843163 
+L 203.151 322.05967 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 239.657 337.768286 
+L 239.657 331.715111 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_161">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="93.633" y="328.329643" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="130.139" y="355.279131" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="166.645" y="334.225954" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="203.151" y="327.843163" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="239.657" y="337.768286" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_162">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="93.633" y="316.200501" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="130.139" y="302.934229" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="166.645" y="329.791538" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="203.151" y="322.05967" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="239.657" y="331.715111" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_15">
+    <path d="M 99.717333 331.430384 
+L 99.717333 322.270799 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 136.223333 325.055082 
+L 136.223333 310.874946 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 172.729333 332.142529 
+L 172.729333 328.022081 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 209.235333 334.135506 
+L 209.235333 317.891619 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.741333 323.489018 
+L 245.741333 320.014869 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_163">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="99.717333" y="331.430384" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="136.223333" y="325.055082" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="172.729333" y="332.142529" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="209.235333" y="334.135506" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="245.741333" y="323.489018" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_164">
+    <g clip-path="url(#pdec16a7099)">
+     <use xlink:href="#m5f82a262da" x="99.717333" y="322.270799" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="136.223333" y="310.874946" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="172.729333" y="328.022081" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="209.235333" y="317.891619" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="245.741333" y="320.014869" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_165">
+    <path d="M 75.38 311.954506 
+L 257.91 311.954506 
+" clip-path="url(#pdec16a7099)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_98">
+    <path d="M 75.38 360.570971 
+L 75.38 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_99">
+    <path d="M 257.91 360.570971 
+L 257.91 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_100">
+    <path d="M 75.38 360.570971 
+L 257.91 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_101">
+    <path d="M 75.38 244.150485 
+L 257.91 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_6">
+   <g id="patch_102">
+    <path d="M 291.41 360.570971 
+L 473.94 360.570971 
+L 473.94 244.150485 
+L 291.41 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_11">
+    <g id="xtick_26">
+     <g id="line2d_166">
+      <path d="M 309.663 360.570971 
+L 309.663 244.150485 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_167">
+      <g>
+       <use xlink:href="#madba55393a" x="309.663" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 4 KiB -->
+      <g transform="translate(296.836746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_168">
+      <path d="M 346.169 360.570971 
+L 346.169 244.150485 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_169">
+      <g>
+       <use xlink:href="#madba55393a" x="346.169" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 32 KiB -->
+      <g transform="translate(328.843779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_170">
+      <path d="M 382.675 360.570971 
+L 382.675 244.150485 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_171">
+      <g>
+       <use xlink:href="#madba55393a" x="382.675" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 256 KiB -->
+      <g transform="translate(360.850812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_172">
+      <path d="M 419.181 360.570971 
+L 419.181 244.150485 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_173">
+      <g>
+       <use xlink:href="#madba55393a" x="419.181" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 1 MiB -->
+      <g transform="translate(404.890814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_174">
+      <path d="M 455.687 360.570971 
+L 455.687 244.150485 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_175">
+      <g>
+       <use xlink:href="#madba55393a" x="455.687" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 16 MiB -->
+      <g transform="translate(436.897847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_12">
+    <g id="ytick_41">
+     <g id="line2d_176">
+      <path d="M 291.41 339.265525 
+L 473.94 339.265525 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_177">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="339.265525" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_178">
+      <path d="M 291.41 311.954506 
+L 473.94 311.954506 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_179">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="311.954506" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_180">
+      <path d="M 291.41 284.643488 
+L 473.94 284.643488 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_181">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="284.643488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_182">
+      <path d="M 291.41 257.33247 
+L 473.94 257.33247 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_183">
+      <g>
+       <use xlink:href="#m682f1ae931" x="291.41" y="257.33247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_184">
+      <path d="M 291.41 352.921034 
+L 473.94 352.921034 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_185">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="352.921034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_186">
+      <path d="M 291.41 325.610016 
+L 473.94 325.610016 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_187">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="325.610016" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_188">
+      <path d="M 291.41 298.298997 
+L 473.94 298.298997 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_189">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="298.298997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_190">
+      <path d="M 291.41 270.987979 
+L 473.94 270.987979 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_191">
+      <g>
+       <use xlink:href="#m19397d4597" x="291.41" y="270.987979" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_103">
+    <path d="M 300.5365 311.954506 
+L 306.620833 311.954506 
+L 306.620833 334.454135 
+L 300.5365 334.454135 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_104">
+    <path d="M 337.0425 311.954506 
+L 343.126833 311.954506 
+L 343.126833 322.38162 
+L 337.0425 322.38162 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_105">
+    <path d="M 373.5485 311.954506 
+L 379.632833 311.954506 
+L 379.632833 338.790965 
+L 373.5485 338.790965 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_106">
+    <path d="M 410.0545 311.954506 
+L 416.138833 311.954506 
+L 416.138833 338.291691 
+L 410.0545 338.291691 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_107">
+    <path d="M 446.5605 311.954506 
+L 452.644833 311.954506 
+L 452.644833 321.471604 
+L 446.5605 321.471604 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_108">
+    <path d="M 306.620833 311.954506 
+L 312.705167 311.954506 
+L 312.705167 328.641815 
+L 306.620833 328.641815 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_109">
+    <path d="M 343.126833 311.954506 
+L 349.211167 311.954506 
+L 349.211167 320.384139 
+L 343.126833 320.384139 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_110">
+    <path d="M 379.632833 311.954506 
+L 385.717167 311.954506 
+L 385.717167 338.447251 
+L 379.632833 338.447251 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_111">
+    <path d="M 416.138833 311.954506 
+L 422.223167 311.954506 
+L 422.223167 337.344083 
+L 416.138833 337.344083 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_112">
+    <path d="M 452.644833 311.954506 
+L 458.729167 311.954506 
+L 458.729167 321.710345 
+L 452.644833 321.710345 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_113">
+    <path d="M 312.705167 311.954506 
+L 318.7895 311.954506 
+L 318.7895 330.50215 
+L 312.705167 330.50215 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_114">
+    <path d="M 349.211167 311.954506 
+L 355.2955 311.954506 
+L 355.2955 314.426822 
+L 349.211167 314.426822 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_115">
+    <path d="M 385.717167 311.954506 
+L 391.8015 311.954506 
+L 391.8015 338.780475 
+L 385.717167 338.780475 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_116">
+    <path d="M 422.223167 311.954506 
+L 428.3075 311.954506 
+L 428.3075 330.8735 
+L 422.223167 330.8735 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_117">
+    <path d="M 458.729167 311.954506 
+L 464.8135 311.954506 
+L 464.8135 320.741356 
+L 458.729167 320.741356 
+z
+" clip-path="url(#p7d416be0a2)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_16">
+    <path d="M 303.578667 339.282698 
+L 303.578667 329.625572 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 340.084667 325.526848 
+L 340.084667 319.236393 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 376.590667 340.622712 
+L 376.590667 336.959219 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 413.096667 340.632166 
+L 413.096667 335.951216 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 449.602667 322.892295 
+L 449.602667 320.050913 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_192">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="303.578667" y="339.282698" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="340.084667" y="325.526848" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="376.590667" y="340.622712" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="413.096667" y="340.632166" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="449.602667" y="322.892295" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_193">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="303.578667" y="329.625572" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="340.084667" y="319.236393" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="376.590667" y="336.959219" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="413.096667" y="335.951216" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="449.602667" y="320.050913" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_17">
+    <path d="M 309.663 335.600786 
+L 309.663 321.682845 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 346.169 344.783063 
+L 346.169 295.985214 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 382.675 340.181587 
+L 382.675 336.712914 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 419.181 339.799771 
+L 419.181 334.888395 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 455.687 323.155481 
+L 455.687 320.26521 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_194">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="309.663" y="335.600786" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="346.169" y="344.783063" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="382.675" y="340.181587" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="419.181" y="339.799771" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="455.687" y="323.155481" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_195">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="309.663" y="321.682845" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="346.169" y="295.985214" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="382.675" y="336.712914" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="419.181" y="334.888395" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="455.687" y="320.26521" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_18">
+    <path d="M 315.747333 336.124527 
+L 315.747333 324.879773 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 352.253333 321.678542 
+L 352.253333 307.175102 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 388.759333 340.613616 
+L 388.759333 336.947335 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 425.265333 333.607737 
+L 425.265333 328.139263 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 461.771333 322.047663 
+L 461.771333 319.43505 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_196">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="315.747333" y="336.124527" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="352.253333" y="321.678542" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="388.759333" y="340.613616" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="425.265333" y="333.607737" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="461.771333" y="322.047663" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_197">
+    <g clip-path="url(#p7d416be0a2)">
+     <use xlink:href="#m5f82a262da" x="315.747333" y="324.879773" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="352.253333" y="307.175102" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="388.759333" y="336.947335" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="425.265333" y="328.139263" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="461.771333" y="319.43505" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_198">
+    <path d="M 291.41 311.954506 
+L 473.94 311.954506 
+" clip-path="url(#p7d416be0a2)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_118">
+    <path d="M 291.41 360.570971 
+L 291.41 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_119">
+    <path d="M 473.94 360.570971 
+L 473.94 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_120">
+    <path d="M 291.41 360.570971 
+L 473.94 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_121">
+    <path d="M 291.41 244.150485 
+L 473.94 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_7">
+   <g id="patch_122">
+    <path d="M 507.44 360.570971 
+L 689.97 360.570971 
+L 689.97 244.150485 
+L 507.44 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_13">
+    <g id="xtick_31">
+     <g id="line2d_199">
+      <path d="M 525.693 360.570971 
+L 525.693 244.150485 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_200">
+      <g>
+       <use xlink:href="#madba55393a" x="525.693" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 4 KiB -->
+      <g transform="translate(512.866746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_201">
+      <path d="M 562.199 360.570971 
+L 562.199 244.150485 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_202">
+      <g>
+       <use xlink:href="#madba55393a" x="562.199" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 32 KiB -->
+      <g transform="translate(544.873779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_203">
+      <path d="M 598.705 360.570971 
+L 598.705 244.150485 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_204">
+      <g>
+       <use xlink:href="#madba55393a" x="598.705" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 256 KiB -->
+      <g transform="translate(576.880812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_205">
+      <path d="M 635.211 360.570971 
+L 635.211 244.150485 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_206">
+      <g>
+       <use xlink:href="#madba55393a" x="635.211" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 1 MiB -->
+      <g transform="translate(620.920814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_207">
+      <path d="M 671.717 360.570971 
+L 671.717 244.150485 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_208">
+      <g>
+       <use xlink:href="#madba55393a" x="671.717" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 16 MiB -->
+      <g transform="translate(652.927847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_14">
+    <g id="ytick_49">
+     <g id="line2d_209">
+      <path d="M 507.44 339.265525 
+L 689.97 339.265525 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_210">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="339.265525" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_211">
+      <path d="M 507.44 311.954506 
+L 689.97 311.954506 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_212">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="311.954506" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_213">
+      <path d="M 507.44 284.643488 
+L 689.97 284.643488 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_214">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="284.643488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_215">
+      <path d="M 507.44 257.33247 
+L 689.97 257.33247 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_216">
+      <g>
+       <use xlink:href="#m682f1ae931" x="507.44" y="257.33247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_217">
+      <path d="M 507.44 352.921034 
+L 689.97 352.921034 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_218">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="352.921034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_219">
+      <path d="M 507.44 325.610016 
+L 689.97 325.610016 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_220">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="325.610016" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_221">
+      <path d="M 507.44 298.298997 
+L 689.97 298.298997 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_222">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="298.298997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_223">
+      <path d="M 507.44 270.987979 
+L 689.97 270.987979 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_224">
+      <g>
+       <use xlink:href="#m19397d4597" x="507.44" y="270.987979" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_123">
+    <path d="M 516.5665 311.954506 
+L 522.650833 311.954506 
+L 522.650833 330.320875 
+L 516.5665 330.320875 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_124">
+    <path d="M 553.0725 311.954506 
+L 559.156833 311.954506 
+L 559.156833 323.501801 
+L 553.0725 323.501801 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_125">
+    <path d="M 589.5785 311.954506 
+L 595.662833 311.954506 
+L 595.662833 339.496514 
+L 589.5785 339.496514 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_126">
+    <path d="M 626.0845 311.954506 
+L 632.168833 311.954506 
+L 632.168833 334.381564 
+L 626.0845 334.381564 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_127">
+    <path d="M 662.5905 311.954506 
+L 668.674833 311.954506 
+L 668.674833 321.36492 
+L 662.5905 321.36492 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_128">
+    <path d="M 522.650833 311.954506 
+L 528.735167 311.954506 
+L 528.735167 326.536531 
+L 522.650833 326.536531 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_129">
+    <path d="M 559.156833 311.954506 
+L 565.241167 311.954506 
+L 565.241167 307.219299 
+L 559.156833 307.219299 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_130">
+    <path d="M 595.662833 311.954506 
+L 601.747167 311.954506 
+L 601.747167 339.129525 
+L 595.662833 339.129525 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_131">
+    <path d="M 632.168833 311.954506 
+L 638.253167 311.954506 
+L 638.253167 336.429367 
+L 632.168833 336.429367 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_132">
+    <path d="M 668.674833 311.954506 
+L 674.759167 311.954506 
+L 674.759167 321.269643 
+L 668.674833 321.269643 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_133">
+    <path d="M 528.735167 311.954506 
+L 534.8195 311.954506 
+L 534.8195 323.603483 
+L 528.735167 323.603483 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_134">
+    <path d="M 565.241167 311.954506 
+L 571.3255 311.954506 
+L 571.3255 325.872034 
+L 565.241167 325.872034 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_135">
+    <path d="M 601.747167 311.954506 
+L 607.8315 311.954506 
+L 607.8315 329.303957 
+L 601.747167 329.303957 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_136">
+    <path d="M 638.253167 311.954506 
+L 644.3375 311.954506 
+L 644.3375 331.86173 
+L 638.253167 331.86173 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_137">
+    <path d="M 674.759167 311.954506 
+L 680.8435 311.954506 
+L 680.8435 320.58807 
+L 674.759167 320.58807 
+z
+" clip-path="url(#pd463b199f4)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_19">
+    <path d="M 519.608667 335.003371 
+L 519.608667 325.63838 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 556.114667 326.247725 
+L 556.114667 320.755877 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 592.620667 341.361644 
+L 592.620667 337.631385 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 629.126667 336.453068 
+L 629.126667 332.31006 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 665.632667 322.747299 
+L 665.632667 319.982541 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_225">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="519.608667" y="335.003371" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="556.114667" y="326.247725" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="592.620667" y="341.361644" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="629.126667" y="336.453068" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="665.632667" y="322.747299" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_226">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="519.608667" y="325.63838" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="556.114667" y="320.755877" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="592.620667" y="337.631385" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="629.126667" y="332.31006" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="665.632667" y="319.982541" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_20">
+    <path d="M 525.693 334.157098 
+L 525.693 318.915965 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 562.199 330.63482 
+L 562.199 283.803779 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 598.705 340.982413 
+L 598.705 337.276638 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 635.211 342.135207 
+L 635.211 330.723528 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 671.717 322.660184 
+L 671.717 319.879103 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_227">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="525.693" y="334.157098" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="562.199" y="330.63482" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="598.705" y="340.982413" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="635.211" y="342.135207" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="671.717" y="322.660184" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_228">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="525.693" y="318.915965" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="562.199" y="283.803779" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="598.705" y="337.276638" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="635.211" y="330.723528" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="671.717" y="319.879103" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_21">
+    <path d="M 531.777333 330.249777 
+L 531.777333 316.957188 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 568.283333 330.948633 
+L 568.283333 320.795435 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 604.789333 333.982075 
+L 604.789333 324.625839 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 641.295333 337.875674 
+L 641.295333 325.847786 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 677.801333 321.881191 
+L 677.801333 319.294949 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_229">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="531.777333" y="330.249777" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="568.283333" y="330.948633" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="604.789333" y="333.982075" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="641.295333" y="337.875674" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="677.801333" y="321.881191" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_230">
+    <g clip-path="url(#pd463b199f4)">
+     <use xlink:href="#m5f82a262da" x="531.777333" y="316.957188" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="568.283333" y="320.795435" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="604.789333" y="324.625839" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="641.295333" y="325.847786" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="677.801333" y="319.294949" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_231">
+    <path d="M 507.44 311.954506 
+L 689.97 311.954506 
+" clip-path="url(#pd463b199f4)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_138">
+    <path d="M 507.44 360.570971 
+L 507.44 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_139">
+    <path d="M 689.97 360.570971 
+L 689.97 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_140">
+    <path d="M 507.44 360.570971 
+L 689.97 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_141">
+    <path d="M 507.44 244.150485 
+L 689.97 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_8">
+   <g id="patch_142">
+    <path d="M 723.47 360.570971 
+L 906 360.570971 
+L 906 244.150485 
+L 723.47 244.150485 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_15">
+    <g id="xtick_36">
+     <g id="line2d_232">
+      <path d="M 741.723 360.570971 
+L 741.723 244.150485 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_233">
+      <g>
+       <use xlink:href="#madba55393a" x="741.723" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 4 KiB -->
+      <g transform="translate(728.896746 391.143038) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_234">
+      <path d="M 778.229 360.570971 
+L 778.229 244.150485 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_235">
+      <g>
+       <use xlink:href="#madba55393a" x="778.229" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 32 KiB -->
+      <g transform="translate(760.903779 395.642005) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_236">
+      <path d="M 814.735 360.570971 
+L 814.735 244.150485 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_237">
+      <g>
+       <use xlink:href="#madba55393a" x="814.735" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 256 KiB -->
+      <g transform="translate(792.910812 400.140972) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_238">
+      <path d="M 851.241 360.570971 
+L 851.241 244.150485 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_239">
+      <g>
+       <use xlink:href="#madba55393a" x="851.241" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 1 MiB -->
+      <g transform="translate(836.950814 392.60697) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_240">
+      <path d="M 887.747 360.570971 
+L 887.747 244.150485 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_241">
+      <g>
+       <use xlink:href="#madba55393a" x="887.747" y="360.570971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 16 MiB -->
+      <g transform="translate(868.957847 397.105937) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_16">
+    <g id="ytick_57">
+     <g id="line2d_242">
+      <path d="M 723.47 339.265525 
+L 906 339.265525 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_243">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="339.265525" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_244">
+      <path d="M 723.47 311.954506 
+L 906 311.954506 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_245">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="311.954506" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_246">
+      <path d="M 723.47 284.643488 
+L 906 284.643488 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_247">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="284.643488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_248">
+      <path d="M 723.47 257.33247 
+L 906 257.33247 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_249">
+      <g>
+       <use xlink:href="#m682f1ae931" x="723.47" y="257.33247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_250">
+      <path d="M 723.47 352.921034 
+L 906 352.921034 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_251">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="352.921034" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_252">
+      <path d="M 723.47 325.610016 
+L 906 325.610016 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_253">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="325.610016" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_63">
+     <g id="line2d_254">
+      <path d="M 723.47 298.298997 
+L 906 298.298997 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_255">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="298.298997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_64">
+     <g id="line2d_256">
+      <path d="M 723.47 270.987979 
+L 906 270.987979 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_257">
+      <g>
+       <use xlink:href="#m19397d4597" x="723.47" y="270.987979" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_143">
+    <path d="M 732.5965 311.954506 
+L 738.680833 311.954506 
+L 738.680833 331.478554 
+L 732.5965 331.478554 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_144">
+    <path d="M 769.1025 311.954506 
+L 775.186833 311.954506 
+L 775.186833 344.739297 
+L 769.1025 344.739297 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_145">
+    <path d="M 805.6085 311.954506 
+L 811.692833 311.954506 
+L 811.692833 334.426291 
+L 805.6085 334.426291 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_146">
+    <path d="M 842.1145 311.954506 
+L 848.198833 311.954506 
+L 848.198833 337.64437 
+L 842.1145 337.64437 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_147">
+    <path d="M 878.6205 311.954506 
+L 884.704833 311.954506 
+L 884.704833 321.550533 
+L 878.6205 321.550533 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_148">
+    <path d="M 738.680833 311.954506 
+L 744.765167 311.954506 
+L 744.765167 327.259999 
+L 738.680833 327.259999 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_149">
+    <path d="M 775.186833 311.954506 
+L 781.271167 311.954506 
+L 781.271167 330.913687 
+L 775.186833 330.913687 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_150">
+    <path d="M 811.692833 311.954506 
+L 817.777167 311.954506 
+L 817.777167 328.265812 
+L 811.692833 328.265812 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_151">
+    <path d="M 848.198833 311.954506 
+L 854.283167 311.954506 
+L 854.283167 332.499499 
+L 848.198833 332.499499 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_152">
+    <path d="M 884.704833 311.954506 
+L 890.789167 311.954506 
+L 890.789167 320.843949 
+L 884.704833 320.843949 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_153">
+    <path d="M 744.765167 311.954506 
+L 750.8495 311.954506 
+L 750.8495 326.158995 
+L 744.765167 326.158995 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_154">
+    <path d="M 781.271167 311.954506 
+L 787.3555 311.954506 
+L 787.3555 334.064398 
+L 781.271167 334.064398 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_155">
+    <path d="M 817.777167 311.954506 
+L 823.8615 311.954506 
+L 823.8615 326.381443 
+L 817.777167 326.381443 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_156">
+    <path d="M 854.283167 311.954506 
+L 860.3675 311.954506 
+L 860.3675 322.674051 
+L 854.283167 322.674051 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_157">
+    <path d="M 890.789167 311.954506 
+L 896.8735 311.954506 
+L 896.8735 321.096965 
+L 890.789167 321.096965 
+z
+" clip-path="url(#pa7afbc6633)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_22">
+    <path d="M 735.638667 336.084344 
+L 735.638667 326.872763 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 772.144667 347.376817 
+L 772.144667 342.101778 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 808.650667 336.148664 
+L 808.650667 332.703918 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 845.156667 339.62074 
+L 845.156667 335.667999 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 881.662667 322.948171 
+L 881.662667 320.152896 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_258">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="735.638667" y="336.084344" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="772.144667" y="347.376817" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="808.650667" y="336.148664" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="845.156667" y="339.62074" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="881.662667" y="322.948171" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_259">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="735.638667" y="326.872763" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="772.144667" y="342.101778" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="808.650667" y="332.703918" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="845.156667" y="335.667999" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="881.662667" y="320.152896" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_23">
+    <path d="M 741.723 334.381457 
+L 741.723 320.138541 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 778.229 353.09317 
+L 778.229 308.734205 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 814.735 333.713499 
+L 814.735 322.818126 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 851.241 334.17921 
+L 851.241 330.819787 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 887.747 322.406594 
+L 887.747 319.281303 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_260">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="741.723" y="334.381457" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="778.229" y="353.09317" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="814.735" y="333.713499" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="851.241" y="334.17921" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="887.747" y="322.406594" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_261">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="741.723" y="320.138541" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="778.229" y="308.734205" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="814.735" y="322.818126" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="851.241" y="330.819787" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="887.747" y="319.281303" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_24">
+    <path d="M 747.807333 332.825074 
+L 747.807333 319.492917 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 784.313333 336.35585 
+L 784.313333 331.772945 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 820.819333 327.557134 
+L 820.819333 325.205752 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 857.325333 327.406417 
+L 857.325333 317.941685 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 893.831333 322.514389 
+L 893.831333 319.679541 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_262">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="747.807333" y="332.825074" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="784.313333" y="336.35585" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="820.819333" y="327.557134" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="857.325333" y="327.406417" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="893.831333" y="322.514389" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_263">
+    <g clip-path="url(#pa7afbc6633)">
+     <use xlink:href="#m5f82a262da" x="747.807333" y="319.492917" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="784.313333" y="331.772945" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="820.819333" y="325.205752" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="857.325333" y="317.941685" style="stroke: #000000"/>
+     <use xlink:href="#m5f82a262da" x="893.831333" y="319.679541" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_264">
+    <path d="M 723.47 311.954506 
+L 906 311.954506 
+" clip-path="url(#pa7afbc6633)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_158">
+    <path d="M 723.47 360.570971 
+L 723.47 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_159">
+    <path d="M 906 360.570971 
+L 906 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_160">
+    <path d="M 723.47 360.570971 
+L 906 360.570971 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_161">
+    <path d="M 723.47 244.150485 
+L 906 244.150485 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_35">
+   <!-- Null Blk Throughput, $\frac{R-C}{C}$ (Bare Metal) -->
+   <g transform="translate(353.7 20.28) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-43" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(0 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(74.804688 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(138.183594 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(165.966797 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(193.75 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(225.537109 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(294.140625 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(321.923828 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(379.833984 0.254687)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(411.621094 0.254687)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(472.705078 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(536.083984 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(577.197266 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(638.378906 0.254687)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(701.757812 0.254687)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(765.234375 0.254687)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(828.613281 0.254687)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(892.089844 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(955.46875 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(994.677734 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1026.464844 0.254687)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1058.251953 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-2212" transform="translate(1120.527344 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(1192.817383 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(1125.251953 -39.151563) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1254.194336 0.254687)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1285.981445 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(1324.995117 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1393.598633 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1454.87793 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1495.991211 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1557.514648 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(1589.301758 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1675.581055 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1737.104492 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1776.313477 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1837.592773 0.254687)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(1865.375977 0.254687)"/>
+    <path d="M 1058.251953 19.051563 
+L 1058.251953 25.301563 
+L 1241.694336 25.301563 
+L 1241.694336 19.051563 
+L 1058.251953 19.051563 
+z
+"/>
+   </g>
+  </g>
+  <g id="text_36">
+   <!-- IO/s Difference Relative -->
+   <g transform="translate(16.958438 274.892187) rotate(-90) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-49"/>
+    <use xlink:href="#DejaVuSans-4f" x="29.492188"/>
+    <use xlink:href="#DejaVuSans-2f" x="108.203125"/>
+    <use xlink:href="#DejaVuSans-73" x="141.894531"/>
+    <use xlink:href="#DejaVuSans-20" x="193.994141"/>
+    <use xlink:href="#DejaVuSans-44" x="225.78125"/>
+    <use xlink:href="#DejaVuSans-69" x="302.783203"/>
+    <use xlink:href="#DejaVuSans-66" x="330.566406"/>
+    <use xlink:href="#DejaVuSans-66" x="365.771484"/>
+    <use xlink:href="#DejaVuSans-65" x="400.976562"/>
+    <use xlink:href="#DejaVuSans-72" x="462.5"/>
+    <use xlink:href="#DejaVuSans-65" x="501.363281"/>
+    <use xlink:href="#DejaVuSans-6e" x="562.886719"/>
+    <use xlink:href="#DejaVuSans-63" x="626.265625"/>
+    <use xlink:href="#DejaVuSans-65" x="681.246094"/>
+    <use xlink:href="#DejaVuSans-20" x="742.769531"/>
+    <use xlink:href="#DejaVuSans-52" x="774.556641"/>
+    <use xlink:href="#DejaVuSans-65" x="839.539062"/>
+    <use xlink:href="#DejaVuSans-6c" x="901.0625"/>
+    <use xlink:href="#DejaVuSans-61" x="928.845703"/>
+    <use xlink:href="#DejaVuSans-74" x="990.125"/>
+    <use xlink:href="#DejaVuSans-69" x="1029.333984"/>
+    <use xlink:href="#DejaVuSans-76" x="1057.117188"/>
+    <use xlink:href="#DejaVuSans-65" x="1116.296875"/>
+   </g>
+  </g>
+  <g id="text_37">
+   <!-- Block Size (KiB) -->
+   <g transform="translate(429.034375 427.68) scale(0.1 -0.1)">
+    <defs>
+     <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-42"/>
+    <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+    <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+    <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+    <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+    <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+    <use xlink:href="#DejaVuSans-53" x="302.246094"/>
+    <use xlink:href="#DejaVuSans-69" x="365.722656"/>
+    <use xlink:href="#DejaVuSans-7a" x="393.505859"/>
+    <use xlink:href="#DejaVuSans-65" x="445.996094"/>
+    <use xlink:href="#DejaVuSans-20" x="507.519531"/>
+    <use xlink:href="#DejaVuSans-28" x="539.306641"/>
+    <use xlink:href="#DejaVuSans-4b" x="578.320312"/>
+    <use xlink:href="#DejaVuSans-69" x="643.896484"/>
+    <use xlink:href="#DejaVuSans-42" x="671.679688"/>
+    <use xlink:href="#DejaVuSans-29" x="740.283203"/>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="patch_162">
+    <path d="M 35.08 59.8 
+L 182.1675 59.8 
+Q 184.1675 59.8 184.1675 57.8 
+L 184.1675 29.44375 
+Q 184.1675 27.44375 182.1675 27.44375 
+L 35.08 27.44375 
+Q 33.08 27.44375 33.08 29.44375 
+L 33.08 57.8 
+Q 33.08 59.8 35.08 59.8 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_38">
+    <!-- Threads (cores) -->
+    <g transform="translate(69.615156 39.042188) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-72" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-65" x="163.326172"/>
+     <use xlink:href="#DejaVuSans-61" x="224.849609"/>
+     <use xlink:href="#DejaVuSans-64" x="286.128906"/>
+     <use xlink:href="#DejaVuSans-73" x="349.605469"/>
+     <use xlink:href="#DejaVuSans-20" x="401.705078"/>
+     <use xlink:href="#DejaVuSans-28" x="433.492188"/>
+     <use xlink:href="#DejaVuSans-63" x="472.505859"/>
+     <use xlink:href="#DejaVuSans-6f" x="527.486328"/>
+     <use xlink:href="#DejaVuSans-72" x="588.667969"/>
+     <use xlink:href="#DejaVuSans-65" x="627.53125"/>
+     <use xlink:href="#DejaVuSans-73" x="689.054688"/>
+     <use xlink:href="#DejaVuSans-29" x="741.154297"/>
+    </g>
+   </g>
+   <g id="patch_163">
+    <path d="M 37.08 53.720313 
+L 57.08 53.720313 
+L 57.08 46.720313 
+L 37.08 46.720313 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_39">
+    <!-- 1 -->
+    <g transform="translate(65.08 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="patch_164">
+    <path d="M 91.4425 53.720313 
+L 111.4425 53.720313 
+L 111.4425 46.720313 
+L 91.4425 46.720313 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_40">
+    <!-- 2 -->
+    <g transform="translate(119.4425 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-32"/>
+    </g>
+   </g>
+   <g id="patch_165">
+    <path d="M 145.805 53.720313 
+L 165.805 53.720313 
+L 165.805 46.720313 
+L 145.805 46.720313 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_41">
+    <!-- 6 -->
+    <g transform="translate(173.805 53.720313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-36"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pe1a35bceb6">
+   <rect x="75.38" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p67b5e85c1d">
+   <rect x="291.41" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p31bf26b7ad">
+   <rect x="507.44" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p8bd39972ad">
+   <rect x="723.47" y="94.23" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="pdec16a7099">
+   <rect x="75.38" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="p7d416be0a2">
+   <rect x="291.41" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="pd463b199f4">
+   <rect x="507.44" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+  <clipPath id="pa7afbc6633">
+   <rect x="723.47" y="244.150485" width="182.53" height="116.420485"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/rnvme/nvme-v6.11-absolute.svg
+++ b/src/rnvme/nvme-v6.11-absolute.svg
@@ -1,0 +1,2331 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="360pt" viewBox="0 0 576 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 576 360 
+L 576 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 72 288 
+L 518.4 288 
+L 518.4 43.2 
+L 72 43.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 109.2 288 
+L 109.2 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m2a37966506" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2a37966506" x="109.2" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 512 B -->
+      <g transform="translate(93.977317 320.968497) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-42" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 183.6 288 
+L 183.6 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m2a37966506" x="183.6" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 KiB -->
+      <g transform="translate(170.773746 318.572067) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 258 288 
+L 258 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m2a37966506" x="258" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 32 KiB -->
+      <g transform="translate(240.674779 323.071034) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 332.4 288 
+L 332.4 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2a37966506" x="332.4" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 256 KiB -->
+      <g transform="translate(310.575812 327.570001) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 406.8 288 
+L 406.8 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2a37966506" x="406.8" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 MiB -->
+      <g transform="translate(392.509814 320.035999) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 481.2 288 
+L 481.2 43.2 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m2a37966506" x="481.2" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 16 MiB -->
+      <g transform="translate(462.410847 324.534966) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Block size -->
+     <g transform="translate(270.392969 340.639) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+      <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+      <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+      <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+      <use xlink:href="#DejaVuSans-73" x="302.246094"/>
+      <use xlink:href="#DejaVuSans-69" x="354.345703"/>
+      <use xlink:href="#DejaVuSans-7a" x="382.128906"/>
+      <use xlink:href="#DejaVuSans-65" x="434.619141"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <path d="M 72 252.533164 
+L 518.4 252.533164 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="mca38e39722" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mca38e39722" x="72" y="252.533164" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(47.4 256.332383) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 72 192.111147 
+L 518.4 192.111147 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mca38e39722" x="72" y="192.111147" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(47.4 195.910365) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 72 131.689129 
+L 518.4 131.689129 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mca38e39722" x="72" y="131.689129" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(47.4 135.488348) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 72 71.267112 
+L 518.4 71.267112 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mca38e39722" x="72" y="71.267112" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{6}}$ -->
+      <g transform="translate(47.4 75.06633) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_21">
+      <path d="M 72 284.126553 
+L 518.4 284.126553 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <defs>
+       <path id="m91400c1d22" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="284.126553" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <path d="M 72 276.577502 
+L 518.4 276.577502 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="276.577502" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_25">
+      <path d="M 72 270.722004 
+L 518.4 270.722004 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="270.722004" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_27">
+      <path d="M 72 265.937713 
+L 518.4 265.937713 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="265.937713" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_29">
+      <path d="M 72 261.892653 
+L 518.4 261.892653 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="261.892653" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 72 258.388662 
+L 518.4 258.388662 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="258.388662" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 72 255.297924 
+L 518.4 255.297924 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="255.297924" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 72 234.344324 
+L 518.4 234.344324 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="234.344324" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_37">
+      <path d="M 72 223.704535 
+L 518.4 223.704535 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="223.704535" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 72 216.155485 
+L 518.4 216.155485 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="216.155485" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 72 210.299986 
+L 518.4 210.299986 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="210.299986" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 72 205.515696 
+L 518.4 205.515696 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="205.515696" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 72 201.470635 
+L 518.4 201.470635 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="201.470635" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_47">
+      <path d="M 72 197.966645 
+L 518.4 197.966645 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="197.966645" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_49">
+      <path d="M 72 194.875906 
+L 518.4 194.875906 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="194.875906" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_51">
+      <path d="M 72 173.922307 
+L 518.4 173.922307 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="173.922307" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_53">
+      <path d="M 72 163.282518 
+L 518.4 163.282518 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="163.282518" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_55">
+      <path d="M 72 155.733467 
+L 518.4 155.733467 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="155.733467" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_57">
+      <path d="M 72 149.877969 
+L 518.4 149.877969 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="149.877969" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_59">
+      <path d="M 72 145.093678 
+L 518.4 145.093678 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="145.093678" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_61">
+      <path d="M 72 141.048618 
+L 518.4 141.048618 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="141.048618" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_63">
+      <path d="M 72 137.544628 
+L 518.4 137.544628 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="137.544628" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_65">
+      <path d="M 72 134.453889 
+L 518.4 134.453889 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="134.453889" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_67">
+      <path d="M 72 113.500289 
+L 518.4 113.500289 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="113.500289" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_69">
+      <path d="M 72 102.8605 
+L 518.4 102.8605 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="102.8605" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_71">
+      <path d="M 72 95.31145 
+L 518.4 95.31145 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="95.31145" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_73">
+      <path d="M 72 89.455951 
+L 518.4 89.455951 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="89.455951" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_75">
+      <path d="M 72 84.671661 
+L 518.4 84.671661 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="84.671661" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_77">
+      <path d="M 72 80.6266 
+L 518.4 80.6266 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="80.6266" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_79">
+      <path d="M 72 77.12261 
+L 518.4 77.12261 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="77.12261" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_81">
+      <path d="M 72 74.031871 
+L 518.4 74.031871 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="74.031871" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_83">
+      <path d="M 72 53.078272 
+L 518.4 53.078272 
+" clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m91400c1d22" x="72" y="53.078272" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- IO/s -->
+     <g transform="translate(41.320312 175.3) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-4f" x="29.492188"/>
+      <use xlink:href="#DejaVuSans-2f" x="108.203125"/>
+      <use xlink:href="#DejaVuSans-73" x="141.894531"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 90.6 60855.816692 
+L 95.25 60855.816692 
+L 95.25 112.825871 
+L 90.6 112.825871 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165 60855.816692 
+L 169.65 60855.816692 
+L 169.65 117.596141 
+L 165 117.596141 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 239.4 60855.816692 
+L 244.05 60855.816692 
+L 244.05 132.613927 
+L 239.4 132.613927 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 313.8 60855.816692 
+L 318.45 60855.816692 
+L 318.45 171.83256 
+L 313.8 171.83256 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 388.2 60855.816692 
+L 392.85 60855.816692 
+L 392.85 206.32591 
+L 388.2 206.32591 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 462.6 60855.816692 
+L 467.25 60855.816692 
+L 467.25 276.378174 
+L 462.6 276.378174 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 95.25 60855.816692 
+L 99.9 60855.816692 
+L 99.9 117.134808 
+L 95.25 117.134808 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 169.65 60855.816692 
+L 174.3 60855.816692 
+L 174.3 121.17266 
+L 169.65 121.17266 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 244.05 60855.816692 
+L 248.7 60855.816692 
+L 248.7 134.96674 
+L 244.05 134.96674 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 318.45 60855.816692 
+L 323.1 60855.816692 
+L 323.1 172.791191 
+L 318.45 172.791191 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 392.85 60855.816692 
+L 397.5 60855.816692 
+L 397.5 207.102518 
+L 392.85 207.102518 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 467.25 60855.816692 
+L 471.9 60855.816692 
+L 471.9 276.405859 
+L 467.25 276.405859 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 99.9 60855.816692 
+L 104.55 60855.816692 
+L 104.55 64.457766 
+L 99.9 64.457766 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 174.3 60855.816692 
+L 178.95 60855.816692 
+L 178.95 67.903096 
+L 174.3 67.903096 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 248.7 60855.816692 
+L 253.35 60855.816692 
+L 253.35 113.829638 
+L 248.7 113.829638 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 323.1 60855.816692 
+L 327.75 60855.816692 
+L 327.75 168.18914 
+L 323.1 168.18914 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 397.5 60855.816692 
+L 402.15 60855.816692 
+L 402.15 211.841154 
+L 397.5 211.841154 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 471.9 60855.816692 
+L 476.55 60855.816692 
+L 476.55 275.993625 
+L 471.9 275.993625 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 104.55 60855.816692 
+L 109.2 60855.816692 
+L 109.2 68.773697 
+L 104.55 68.773697 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 178.95 60855.816692 
+L 183.6 60855.816692 
+L 183.6 72.123442 
+L 178.95 72.123442 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 253.35 60855.816692 
+L 258 60855.816692 
+L 258 113.799187 
+L 253.35 113.799187 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 327.75 60855.816692 
+L 332.4 60855.816692 
+L 332.4 168.150282 
+L 327.75 168.150282 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 402.15 60855.816692 
+L 406.8 60855.816692 
+L 406.8 211.843102 
+L 402.15 211.843102 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 476.55 60855.816692 
+L 481.2 60855.816692 
+L 481.2 275.993625 
+L 476.55 275.993625 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 109.2 60855.816692 
+L 113.85 60855.816692 
+L 113.85 54.992471 
+L 109.2 54.992471 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 183.6 60855.816692 
+L 188.25 60855.816692 
+L 188.25 65.821621 
+L 183.6 65.821621 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 258 60855.816692 
+L 262.65 60855.816692 
+L 262.65 115.306699 
+L 258 115.306699 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 332.4 60855.816692 
+L 337.05 60855.816692 
+L 337.05 175.621458 
+L 332.4 175.621458 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 406.8 60855.816692 
+L 411.45 60855.816692 
+L 411.45 212.007537 
+L 406.8 212.007537 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 481.2 60855.816692 
+L 485.85 60855.816692 
+L 485.85 276.053039 
+L 481.2 276.053039 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 113.85 60855.816692 
+L 118.5 60855.816692 
+L 118.5 57.881708 
+L 113.85 57.881708 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 188.25 60855.816692 
+L 192.9 60855.816692 
+L 192.9 60.116967 
+L 188.25 60.116967 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 262.65 60855.816692 
+L 267.3 60855.816692 
+L 267.3 113.552518 
+L 262.65 113.552518 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 337.05 60855.816692 
+L 341.7 60855.816692 
+L 341.7 175.621458 
+L 337.05 175.621458 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 411.45 60855.816692 
+L 416.1 60855.816692 
+L 416.1 212.007537 
+L 411.45 212.007537 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 485.85 60855.816692 
+L 490.5 60855.816692 
+L 490.5 275.993625 
+L 485.85 275.993625 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 118.5 60855.816692 
+L 123.15 60855.816692 
+L 123.15 54.327273 
+L 118.5 54.327273 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 192.9 60855.816692 
+L 197.55 60855.816692 
+L 197.55 66.465973 
+L 192.9 66.465973 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 267.3 60855.816692 
+L 271.95 60855.816692 
+L 271.95 121.044875 
+L 267.3 121.044875 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 341.7 60855.816692 
+L 346.35 60855.816692 
+L 346.35 175.625657 
+L 341.7 175.625657 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 416.1 60855.816692 
+L 420.75 60855.816692 
+L 420.75 212.024346 
+L 416.1 212.024346 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 490.5 60855.816692 
+L 495.15 60855.816692 
+L 495.15 276.489088 
+L 490.5 276.489088 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 123.15 60855.816692 
+L 127.8 60855.816692 
+L 127.8 57.319258 
+L 123.15 57.319258 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 197.55 60855.816692 
+L 202.2 60855.816692 
+L 202.2 65.801783 
+L 197.55 65.801783 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 271.95 60855.816692 
+L 276.6 60855.816692 
+L 276.6 118.886669 
+L 271.95 118.886669 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 346.35 60855.816692 
+L 351 60855.816692 
+L 351 175.625657 
+L 346.35 175.625657 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 420.75 60855.816692 
+L 425.4 60855.816692 
+L 425.4 212.024346 
+L 420.75 212.024346 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 495.15 60855.816692 
+L 499.8 60855.816692 
+L 499.8 276.872727 
+L 495.15 276.872727 
+z
+" clip-path="url(#pdffcf9832a)" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="line2d_85">
+    <path clip-path="url(#pdffcf9832a)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 72 288 
+L 72 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 518.4 288 
+L 518.4 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 72 288 
+L 518.4 288 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 72 43.2 
+L 518.4 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Random read throughput (Bare Metal, 1 core) -->
+    <g transform="translate(158.094375 37.2) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-52"/>
+     <use xlink:href="#DejaVuSans-61" x="67.232422"/>
+     <use xlink:href="#DejaVuSans-6e" x="128.511719"/>
+     <use xlink:href="#DejaVuSans-64" x="191.890625"/>
+     <use xlink:href="#DejaVuSans-6f" x="255.367188"/>
+     <use xlink:href="#DejaVuSans-6d" x="316.548828"/>
+     <use xlink:href="#DejaVuSans-20" x="413.960938"/>
+     <use xlink:href="#DejaVuSans-72" x="445.748047"/>
+     <use xlink:href="#DejaVuSans-65" x="484.611328"/>
+     <use xlink:href="#DejaVuSans-61" x="546.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="607.414062"/>
+     <use xlink:href="#DejaVuSans-20" x="670.890625"/>
+     <use xlink:href="#DejaVuSans-74" x="702.677734"/>
+     <use xlink:href="#DejaVuSans-68" x="741.886719"/>
+     <use xlink:href="#DejaVuSans-72" x="805.265625"/>
+     <use xlink:href="#DejaVuSans-6f" x="844.128906"/>
+     <use xlink:href="#DejaVuSans-75" x="905.310547"/>
+     <use xlink:href="#DejaVuSans-67" x="968.689453"/>
+     <use xlink:href="#DejaVuSans-68" x="1032.166016"/>
+     <use xlink:href="#DejaVuSans-70" x="1095.544922"/>
+     <use xlink:href="#DejaVuSans-75" x="1159.021484"/>
+     <use xlink:href="#DejaVuSans-74" x="1222.400391"/>
+     <use xlink:href="#DejaVuSans-20" x="1261.609375"/>
+     <use xlink:href="#DejaVuSans-28" x="1293.396484"/>
+     <use xlink:href="#DejaVuSans-42" x="1332.410156"/>
+     <use xlink:href="#DejaVuSans-61" x="1401.013672"/>
+     <use xlink:href="#DejaVuSans-72" x="1462.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="1501.15625"/>
+     <use xlink:href="#DejaVuSans-20" x="1562.679688"/>
+     <use xlink:href="#DejaVuSans-4d" x="1594.466797"/>
+     <use xlink:href="#DejaVuSans-65" x="1680.746094"/>
+     <use xlink:href="#DejaVuSans-74" x="1742.269531"/>
+     <use xlink:href="#DejaVuSans-61" x="1781.478516"/>
+     <use xlink:href="#DejaVuSans-6c" x="1842.757812"/>
+     <use xlink:href="#DejaVuSans-2c" x="1870.541016"/>
+     <use xlink:href="#DejaVuSans-20" x="1902.328125"/>
+     <use xlink:href="#DejaVuSans-31" x="1934.115234"/>
+     <use xlink:href="#DejaVuSans-20" x="1997.738281"/>
+     <use xlink:href="#DejaVuSans-63" x="2029.525391"/>
+     <use xlink:href="#DejaVuSans-6f" x="2084.505859"/>
+     <use xlink:href="#DejaVuSans-72" x="2145.6875"/>
+     <use xlink:href="#DejaVuSans-65" x="2184.550781"/>
+     <use xlink:href="#DejaVuSans-29" x="2246.074219"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_55">
+     <path d="M 385.08125 183.303125 
+L 511.4 183.303125 
+Q 513.4 183.303125 513.4 181.303125 
+L 513.4 50.2 
+Q 513.4 48.2 511.4 48.2 
+L 385.08125 48.2 
+Q 383.08125 48.2 383.08125 50.2 
+L 383.08125 181.303125 
+Q 383.08125 183.303125 385.08125 183.303125 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_14">
+     <!-- Configuration (lang, QD) -->
+     <g transform="translate(387.08125 59.798437) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6e" x="131.005859"/>
+      <use xlink:href="#DejaVuSans-66" x="194.384766"/>
+      <use xlink:href="#DejaVuSans-69" x="229.589844"/>
+      <use xlink:href="#DejaVuSans-67" x="257.373047"/>
+      <use xlink:href="#DejaVuSans-75" x="320.849609"/>
+      <use xlink:href="#DejaVuSans-72" x="384.228516"/>
+      <use xlink:href="#DejaVuSans-61" x="425.341797"/>
+      <use xlink:href="#DejaVuSans-74" x="486.621094"/>
+      <use xlink:href="#DejaVuSans-69" x="525.830078"/>
+      <use xlink:href="#DejaVuSans-6f" x="553.613281"/>
+      <use xlink:href="#DejaVuSans-6e" x="614.794922"/>
+      <use xlink:href="#DejaVuSans-20" x="678.173828"/>
+      <use xlink:href="#DejaVuSans-28" x="709.960938"/>
+      <use xlink:href="#DejaVuSans-6c" x="748.974609"/>
+      <use xlink:href="#DejaVuSans-61" x="776.757812"/>
+      <use xlink:href="#DejaVuSans-6e" x="838.037109"/>
+      <use xlink:href="#DejaVuSans-67" x="901.416016"/>
+      <use xlink:href="#DejaVuSans-2c" x="964.892578"/>
+      <use xlink:href="#DejaVuSans-20" x="996.679688"/>
+      <use xlink:href="#DejaVuSans-51" x="1028.466797"/>
+      <use xlink:href="#DejaVuSans-44" x="1107.177734"/>
+      <use xlink:href="#DejaVuSans-29" x="1184.179688"/>
+     </g>
+    </g>
+    <g id="patch_56">
+     <path d="M 410.535937 74.476562 
+L 430.535937 74.476562 
+L 430.535937 67.476562 
+L 410.535937 67.476562 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_15">
+     <!-- C, 1 -->
+     <g transform="translate(438.535937 74.476562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-31" x="133.398438"/>
+     </g>
+    </g>
+    <g id="patch_57">
+     <path d="M 410.535937 89.154688 
+L 430.535937 89.154688 
+L 430.535937 82.154688 
+L 410.535937 82.154688 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_16">
+     <!-- Rust, 1 -->
+     <g transform="translate(438.535937 89.154688) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-31" x="283.244141"/>
+     </g>
+    </g>
+    <g id="patch_58">
+     <path d="M 410.535937 103.832812 
+L 430.535937 103.832812 
+L 430.535937 96.832812 
+L 410.535937 96.832812 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_17">
+     <!-- C, 8 -->
+     <g transform="translate(438.535937 103.832812) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-38" x="133.398438"/>
+     </g>
+    </g>
+    <g id="patch_59">
+     <path d="M 410.535937 118.510938 
+L 430.535937 118.510938 
+L 430.535937 111.510938 
+L 410.535937 111.510938 
+z
+" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_18">
+     <!-- Rust, 8 -->
+     <g transform="translate(438.535937 118.510938) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-38" x="283.244141"/>
+     </g>
+    </g>
+    <g id="patch_60">
+     <path d="M 410.535937 133.189063 
+L 430.535937 133.189063 
+L 430.535937 126.189063 
+L 410.535937 126.189063 
+z
+" style="fill: url(#h41f373e9b8); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_19">
+     <!-- C, 32 -->
+     <g transform="translate(438.535937 133.189063) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-33" x="133.398438"/>
+      <use xlink:href="#DejaVuSans-32" x="197.021484"/>
+     </g>
+    </g>
+    <g id="patch_61">
+     <path d="M 410.535937 147.867188 
+L 430.535937 147.867188 
+L 430.535937 140.867188 
+L 410.535937 140.867188 
+z
+" style="fill: url(#h189ab24a6e); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- Rust, 32 -->
+     <g transform="translate(438.535937 147.867188) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-33" x="283.244141"/>
+      <use xlink:href="#DejaVuSans-32" x="346.867188"/>
+     </g>
+    </g>
+    <g id="patch_62">
+     <path d="M 410.535937 162.545312 
+L 430.535937 162.545312 
+L 430.535937 155.545312 
+L 410.535937 155.545312 
+z
+" style="fill: url(#h0ecc63393b); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <!-- C, 128 -->
+     <g transform="translate(438.535937 162.545312) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-31" x="133.398438"/>
+      <use xlink:href="#DejaVuSans-32" x="197.021484"/>
+      <use xlink:href="#DejaVuSans-38" x="260.644531"/>
+     </g>
+    </g>
+    <g id="patch_63">
+     <path d="M 410.535937 177.223437 
+L 430.535937 177.223437 
+L 430.535937 170.223437 
+L 410.535937 170.223437 
+z
+" style="fill: url(#hf60cc52396); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <!-- Rust, 128 -->
+     <g transform="translate(438.535937 177.223437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-31" x="283.244141"/>
+      <use xlink:href="#DejaVuSans-32" x="346.867188"/>
+      <use xlink:href="#DejaVuSans-38" x="410.490234"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pdffcf9832a">
+   <rect x="72" y="43.2" width="446.4" height="244.8"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h41f373e9b8" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#72ab97"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="h189ab24a6e" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#728ca6"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="h0ecc63393b" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#ffdcaa"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="hf60cc52396" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#ffc6aa"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/src/rnvme/nvme-v6.11-relative.svg
+++ b/src/rnvme/nvme-v6.11-relative.svg
@@ -1,0 +1,1880 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="360pt" viewBox="0 0 432 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 432 360 
+L 432 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54 288 
+L 388.8 288 
+L 388.8 43.2 
+L 54 43.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 81.9 288 
+L 81.9 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m3aea6da8ff" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="81.9" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 512 B -->
+      <g transform="translate(66.677317 320.968497) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-42" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 137.7 288 
+L 137.7 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="137.7" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 KiB -->
+      <g transform="translate(124.873746 318.572067) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 193.5 288 
+L 193.5 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="193.5" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 32 KiB -->
+      <g transform="translate(176.174779 323.071034) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 249.3 288 
+L 249.3 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="249.3" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 256 KiB -->
+      <g transform="translate(227.475812 327.570001) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 305.1 288 
+L 305.1 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="305.1" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 MiB -->
+      <g transform="translate(290.809814 320.035999) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 360.9 288 
+L 360.9 43.2 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m3aea6da8ff" x="360.9" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 16 MiB -->
+      <g transform="translate(342.110847 324.534966) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Block size -->
+     <g transform="translate(196.592969 340.639) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+      <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+      <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+      <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+      <use xlink:href="#DejaVuSans-73" x="302.246094"/>
+      <use xlink:href="#DejaVuSans-69" x="354.345703"/>
+      <use xlink:href="#DejaVuSans-7a" x="382.128906"/>
+      <use xlink:href="#DejaVuSans-65" x="434.619141"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <path d="M 54 275.318551 
+L 388.8 275.318551 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m8275ceb12f" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="275.318551" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- −0.15 -->
+      <g transform="translate(16.354687 279.11777) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 54 247.366251 
+L 388.8 247.366251 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="247.366251" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- −0.10 -->
+      <g transform="translate(16.354687 251.165469) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 54 219.41395 
+L 388.8 219.41395 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="219.41395" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- −0.05 -->
+      <g transform="translate(16.354687 223.213169) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 54 191.46165 
+L 388.8 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="191.46165" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.00 -->
+      <g transform="translate(24.734375 195.260869) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_21">
+      <path d="M 54 163.50935 
+L 388.8 163.50935 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="163.50935" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.05 -->
+      <g transform="translate(24.734375 167.308569) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <path d="M 54 135.55705 
+L 388.8 135.55705 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="135.55705" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.10 -->
+      <g transform="translate(24.734375 139.356268) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_25">
+      <path d="M 54 107.604749 
+L 388.8 107.604749 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="107.604749" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.15 -->
+      <g transform="translate(24.734375 111.403968) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_27">
+      <path d="M 54 79.652449 
+L 388.8 79.652449 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="79.652449" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.20 -->
+      <g transform="translate(24.734375 83.451668) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_29">
+      <path d="M 54 51.700149 
+L 388.8 51.700149 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m8275ceb12f" x="54" y="51.700149" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.25 -->
+      <g transform="translate(24.734375 55.499368) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 54 261.342401 
+L 388.8 261.342401 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <defs>
+       <path id="m7dd5979d7b" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="261.342401" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 54 233.390101 
+L 388.8 233.390101 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="233.390101" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 54 205.4378 
+L 388.8 205.4378 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="205.4378" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_37">
+      <path d="M 54 177.4855 
+L 388.8 177.4855 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="177.4855" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 54 149.5332 
+L 388.8 149.5332 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="149.5332" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 54 121.580899 
+L 388.8 121.580899 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="121.580899" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 54 93.628599 
+L 388.8 93.628599 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="93.628599" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 54 65.676299 
+L 388.8 65.676299 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m7dd5979d7b" x="54" y="65.676299" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- Relative difference -->
+     <g transform="translate(10.275 212.527344) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-65" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-6c" x="126.505859"/>
+      <use xlink:href="#DejaVuSans-61" x="154.289062"/>
+      <use xlink:href="#DejaVuSans-74" x="215.568359"/>
+      <use xlink:href="#DejaVuSans-69" x="254.777344"/>
+      <use xlink:href="#DejaVuSans-76" x="282.560547"/>
+      <use xlink:href="#DejaVuSans-65" x="341.740234"/>
+      <use xlink:href="#DejaVuSans-20" x="403.263672"/>
+      <use xlink:href="#DejaVuSans-64" x="435.050781"/>
+      <use xlink:href="#DejaVuSans-69" x="498.527344"/>
+      <use xlink:href="#DejaVuSans-66" x="526.310547"/>
+      <use xlink:href="#DejaVuSans-66" x="561.515625"/>
+      <use xlink:href="#DejaVuSans-65" x="596.720703"/>
+      <use xlink:href="#DejaVuSans-72" x="658.244141"/>
+      <use xlink:href="#DejaVuSans-65" x="697.107422"/>
+      <use xlink:href="#DejaVuSans-6e" x="758.630859"/>
+      <use xlink:href="#DejaVuSans-63" x="822.009766"/>
+      <use xlink:href="#DejaVuSans-65" x="876.990234"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 67.95 191.46165 
+L 74.925 191.46165 
+L 74.925 276.119841 
+L 67.95 276.119841 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 123.75 191.46165 
+L 130.725 191.46165 
+L 130.725 262.69255 
+L 123.75 262.69255 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 179.55 191.46165 
+L 186.525 191.46165 
+L 186.525 239.405297 
+L 179.55 239.405297 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 235.35 191.46165 
+L 242.325 191.46165 
+L 242.325 211.516102 
+L 235.35 211.516102 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 291.15 191.46165 
+L 298.125 191.46165 
+L 298.125 207.764346 
+L 291.15 207.764346 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 346.95 191.46165 
+L 353.925 191.46165 
+L 353.925 192.051142 
+L 346.95 192.051142 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 74.925 191.46165 
+L 81.9 191.46165 
+L 81.9 276.246257 
+L 74.925 276.246257 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 130.725 191.46165 
+L 137.7 191.46165 
+L 137.7 274.515573 
+L 130.725 274.515573 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 186.525 191.46165 
+L 193.5 191.46165 
+L 193.5 190.812538 
+L 186.525 190.812538 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 242.325 191.46165 
+L 249.3 191.46165 
+L 249.3 190.633204 
+L 242.325 190.633204 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 298.125 191.46165 
+L 305.1 191.46165 
+L 305.1 191.503151 
+L 298.125 191.503151 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 353.925 191.46165 
+L 360.9 191.46165 
+L 360.9 191.46165 
+L 353.925 191.46165 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 81.9 191.46165 
+L 88.875 191.46165 
+L 88.875 249.747304 
+L 81.9 249.747304 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 137.7 191.46165 
+L 144.675 191.46165 
+L 144.675 55.705677 
+L 137.7 55.705677 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 193.5 191.46165 
+L 200.475 191.46165 
+L 200.475 152.812547 
+L 193.5 152.812547 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 249.3 191.46165 
+L 256.275 191.46165 
+L 256.275 191.46165 
+L 249.3 191.46165 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 305.1 191.46165 
+L 312.075 191.46165 
+L 312.075 191.46165 
+L 305.1 191.46165 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 360.9 191.46165 
+L 367.875 191.46165 
+L 367.875 190.194438 
+L 360.9 190.194438 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 88.875 191.46165 
+L 95.85 191.46165 
+L 95.85 251.704239 
+L 88.875 251.704239 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 144.675 191.46165 
+L 151.65 191.46165 
+L 151.65 177.130928 
+L 144.675 177.130928 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 200.475 191.46165 
+L 207.45 191.46165 
+L 207.45 143.538784 
+L 200.475 143.538784 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 256.275 191.46165 
+L 263.25 191.46165 
+L 263.25 191.46165 
+L 256.275 191.46165 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 312.075 191.46165 
+L 319.05 191.46165 
+L 319.05 191.46165 
+L 312.075 191.46165 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 367.875 191.46165 
+L 374.85 191.46165 
+L 374.85 199.575374 
+L 367.875 199.575374 
+z
+" clip-path="url(#p0a2feccfb9)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 71.4375 276.54134 
+L 71.4375 275.698341 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 127.2375 263.246245 
+L 127.2375 262.138854 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 183.0375 239.855383 
+L 183.0375 238.955212 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 238.8375 211.677117 
+L 238.8375 211.355088 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 294.6375 207.855089 
+L 294.6375 207.673602 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 350.4375 192.289465 
+L 350.4375 191.812818 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_47">
+    <defs>
+     <path id="medc6ded156" d="M 1.5 0 
+L -1.5 -0 
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="71.4375" y="276.54134" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="127.2375" y="263.246245" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="183.0375" y="239.855383" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="238.8375" y="211.677117" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="294.6375" y="207.855089" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="350.4375" y="192.289465" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_48">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="71.4375" y="275.698341" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="127.2375" y="262.138854" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="183.0375" y="238.955212" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="238.8375" y="211.355088" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="294.6375" y="207.673602" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="350.4375" y="191.812818" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 78.4125 276.872727 
+L 78.4125 275.619787 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 134.2125 275.128736 
+L 134.2125 273.90241 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 190.0125 191.004437 
+L 190.0125 190.620639 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.8125 190.818373 
+L 245.8125 190.448036 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 301.6125 191.630754 
+L 301.6125 191.375547 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 357.4125 191.46165 
+L 357.4125 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_49">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="78.4125" y="276.872727" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="134.2125" y="275.128736" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="190.0125" y="191.004437" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="245.8125" y="190.818373" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="301.6125" y="191.630754" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="357.4125" y="191.46165" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_50">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="78.4125" y="275.619787" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="134.2125" y="273.90241" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="190.0125" y="190.620639" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="245.8125" y="190.448036" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="301.6125" y="191.375547" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="357.4125" y="191.46165" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 85.3875 251.823077 
+L 85.3875 247.671531 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 141.1875 57.084082 
+L 141.1875 54.327273 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 196.9875 154.005171 
+L 196.9875 151.619924 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 252.7875 191.46165 
+L 252.7875 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 308.5875 191.46165 
+L 308.5875 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 364.3875 190.311216 
+L 364.3875 190.077661 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_51">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="85.3875" y="251.823077" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="141.1875" y="57.084082" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="196.9875" y="154.005171" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="252.7875" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="308.5875" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="364.3875" y="190.311216" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_52">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="85.3875" y="247.671531" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="141.1875" y="54.327273" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="196.9875" y="151.619924" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="252.7875" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="308.5875" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="364.3875" y="190.077661" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 92.3625 252.920651 
+L 92.3625 250.487827 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 148.1625 185.703644 
+L 148.1625 168.558212 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.9625 148.614971 
+L 203.9625 138.462598 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 259.7625 191.46165 
+L 259.7625 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 315.5625 191.46165 
+L 315.5625 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 371.3625 200.507635 
+L 371.3625 198.643112 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_53">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="92.3625" y="252.920651" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="148.1625" y="185.703644" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="203.9625" y="148.614971" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="259.7625" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="315.5625" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="371.3625" y="200.507635" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <g clip-path="url(#p0a2feccfb9)">
+     <use xlink:href="#medc6ded156" x="92.3625" y="250.487827" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="148.1625" y="168.558212" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="203.9625" y="138.462598" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="259.7625" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="315.5625" y="191.46165" style="stroke: #000000"/>
+     <use xlink:href="#medc6ded156" x="371.3625" y="198.643112" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_55">
+    <path d="M 54 191.46165 
+L 388.8 191.46165 
+" clip-path="url(#p0a2feccfb9)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 54 288 
+L 54 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 388.8 288 
+L 388.8 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 54 288 
+L 388.8 288 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 54 43.2 
+L 388.8 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_18">
+   <!-- NVMe randread, $\frac{R-C}{C}$ (Bare Metal, 1 core) -->
+   <g transform="translate(91.98 18.84) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-43" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(0 0.254687)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(74.804688 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(143.212891 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(229.492188 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(291.015625 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(322.802734 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(363.916016 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(425.195312 0.254687)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(488.574219 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(552.050781 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(593.164062 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(654.6875 0.254687)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(715.966797 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(779.443359 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(811.230469 0.254687)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(843.017578 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-2212" transform="translate(905.292969 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(977.583008 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(910.017578 -39.151563) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1038.959961 0.254687)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1070.74707 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(1109.760742 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1178.364258 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1239.643555 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1280.756836 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1342.280273 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(1374.067383 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1460.34668 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1521.870117 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1561.079102 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1622.358398 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1650.141602 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1681.928711 0.254687)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1713.71582 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1777.338867 0.254687)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1809.125977 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1864.106445 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1925.288086 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1966.401367 0.254687)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2027.924805 0.254687)"/>
+    <path d="M 843.017578 19.051563 
+L 843.017578 25.301563 
+L 1026.459961 25.301563 
+L 1026.459961 19.051563 
+L 843.017578 19.051563 
+z
+"/>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="patch_31">
+    <path d="M 355.860937 81.390625 
+L 425 81.390625 
+Q 427 81.390625 427 79.390625 
+L 427 7 
+Q 427 5 425 5 
+L 355.860937 5 
+Q 353.860937 5 353.860937 7 
+L 353.860937 79.390625 
+Q 353.860937 81.390625 355.860937 81.390625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- Queue depth -->
+    <g transform="translate(357.860937 16.598437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-51"/>
+     <use xlink:href="#DejaVuSans-75" x="78.710938"/>
+     <use xlink:href="#DejaVuSans-65" x="142.089844"/>
+     <use xlink:href="#DejaVuSans-75" x="203.613281"/>
+     <use xlink:href="#DejaVuSans-65" x="266.992188"/>
+     <use xlink:href="#DejaVuSans-20" x="328.515625"/>
+     <use xlink:href="#DejaVuSans-64" x="360.302734"/>
+     <use xlink:href="#DejaVuSans-65" x="423.779297"/>
+     <use xlink:href="#DejaVuSans-70" x="485.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="548.779297"/>
+     <use xlink:href="#DejaVuSans-68" x="587.988281"/>
+    </g>
+   </g>
+   <g id="patch_32">
+    <path d="M 366.886719 31.276563 
+L 386.886719 31.276563 
+L 386.886719 24.276563 
+L 366.886719 24.276563 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 1 -->
+    <g transform="translate(394.886719 31.276563) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="patch_33">
+    <path d="M 366.886719 45.954688 
+L 386.886719 45.954688 
+L 386.886719 38.954688 
+L 366.886719 38.954688 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 8 -->
+    <g transform="translate(394.886719 45.954688) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+    </g>
+   </g>
+   <g id="patch_34">
+    <path d="M 366.886719 60.632812 
+L 386.886719 60.632812 
+L 386.886719 53.632812 
+L 366.886719 53.632812 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 32 -->
+    <g transform="translate(394.886719 60.632812) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+    </g>
+   </g>
+   <g id="patch_35">
+    <path d="M 366.886719 75.310938 
+L 386.886719 75.310938 
+L 386.886719 68.310938 
+L 366.886719 68.310938 
+z
+" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 128 -->
+    <g transform="translate(394.886719 75.310938) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p0a2feccfb9">
+   <rect x="54" y="43.2" width="334.8" height="244.8"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/rnvme/nvme-v6.12-rc2-absolute.svg
+++ b/src/rnvme/nvme-v6.12-rc2-absolute.svg
@@ -1,0 +1,2331 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="360pt" viewBox="0 0 576 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 576 360 
+L 576 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 72 288 
+L 518.4 288 
+L 518.4 43.2 
+L 72 43.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 109.2 288 
+L 109.2 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m227ff82998" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m227ff82998" x="109.2" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 512 B -->
+      <g transform="translate(93.977317 320.968497) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-42" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 183.6 288 
+L 183.6 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m227ff82998" x="183.6" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 KiB -->
+      <g transform="translate(170.773746 318.572067) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 258 288 
+L 258 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m227ff82998" x="258" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 32 KiB -->
+      <g transform="translate(240.674779 323.071034) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 332.4 288 
+L 332.4 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m227ff82998" x="332.4" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 256 KiB -->
+      <g transform="translate(310.575812 327.570001) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 406.8 288 
+L 406.8 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m227ff82998" x="406.8" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 MiB -->
+      <g transform="translate(392.509814 320.035999) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 481.2 288 
+L 481.2 43.2 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m227ff82998" x="481.2" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 16 MiB -->
+      <g transform="translate(462.410847 324.534966) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Block size -->
+     <g transform="translate(270.392969 340.639) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+      <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+      <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+      <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+      <use xlink:href="#DejaVuSans-73" x="302.246094"/>
+      <use xlink:href="#DejaVuSans-69" x="354.345703"/>
+      <use xlink:href="#DejaVuSans-7a" x="382.128906"/>
+      <use xlink:href="#DejaVuSans-65" x="434.619141"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <path d="M 72 252.533016 
+L 518.4 252.533016 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m4a5b59b4a5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4a5b59b4a5" x="72" y="252.533016" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(47.4 256.332235) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 72 191.933303 
+L 518.4 191.933303 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m4a5b59b4a5" x="72" y="191.933303" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(47.4 195.732521) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 72 131.333589 
+L 518.4 131.333589 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m4a5b59b4a5" x="72" y="131.333589" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(47.4 135.132808) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 72 70.733875 
+L 518.4 70.733875 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m4a5b59b4a5" x="72" y="70.733875" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{6}}$ -->
+      <g transform="translate(47.4 74.533094) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_21">
+      <path d="M 72 284.219319 
+L 518.4 284.219319 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <defs>
+       <path id="m90c89ea60f" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="284.219319" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <path d="M 72 276.648067 
+L 518.4 276.648067 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="276.648067" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_25">
+      <path d="M 72 270.775348 
+L 518.4 270.775348 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="270.775348" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_27">
+      <path d="M 72 265.976987 
+L 518.4 265.976987 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="265.976987" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_29">
+      <path d="M 72 261.920031 
+L 518.4 261.920031 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="261.920031" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 72 258.405736 
+L 518.4 258.405736 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="258.405736" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 72 255.305907 
+L 518.4 255.305907 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="255.305907" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 72 234.290685 
+L 518.4 234.290685 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="234.290685" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_37">
+      <path d="M 72 223.619605 
+L 518.4 223.619605 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="223.619605" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 72 216.048353 
+L 518.4 216.048353 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="216.048353" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 72 210.175634 
+L 518.4 210.175634 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="210.175634" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 72 205.377273 
+L 518.4 205.377273 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="205.377273" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 72 201.320317 
+L 518.4 201.320317 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="201.320317" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_47">
+      <path d="M 72 197.806022 
+L 518.4 197.806022 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="197.806022" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_49">
+      <path d="M 72 194.706194 
+L 518.4 194.706194 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="194.706194" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_51">
+      <path d="M 72 173.690971 
+L 518.4 173.690971 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="173.690971" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_53">
+      <path d="M 72 163.019891 
+L 518.4 163.019891 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="163.019891" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_55">
+      <path d="M 72 155.44864 
+L 518.4 155.44864 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="155.44864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_57">
+      <path d="M 72 149.575921 
+L 518.4 149.575921 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="149.575921" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_59">
+      <path d="M 72 144.77756 
+L 518.4 144.77756 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="144.77756" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_61">
+      <path d="M 72 140.720603 
+L 518.4 140.720603 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="140.720603" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_63">
+      <path d="M 72 137.206308 
+L 518.4 137.206308 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="137.206308" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_65">
+      <path d="M 72 134.10648 
+L 518.4 134.10648 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="134.10648" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_67">
+      <path d="M 72 113.091257 
+L 518.4 113.091257 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="113.091257" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_69">
+      <path d="M 72 102.420177 
+L 518.4 102.420177 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="102.420177" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_71">
+      <path d="M 72 94.848926 
+L 518.4 94.848926 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="94.848926" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_73">
+      <path d="M 72 88.976207 
+L 518.4 88.976207 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="88.976207" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_75">
+      <path d="M 72 84.177846 
+L 518.4 84.177846 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="84.177846" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_77">
+      <path d="M 72 80.12089 
+L 518.4 80.12089 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="80.12089" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_79">
+      <path d="M 72 76.606594 
+L 518.4 76.606594 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="76.606594" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_81">
+      <path d="M 72 73.506766 
+L 518.4 73.506766 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="73.506766" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_83">
+      <path d="M 72 52.491544 
+L 518.4 52.491544 
+" clip-path="url(#p6664958aee)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m90c89ea60f" x="72" y="52.491544" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- IO/s -->
+     <g transform="translate(41.320312 175.3) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-4f" x="29.492188"/>
+      <use xlink:href="#DejaVuSans-2f" x="108.203125"/>
+      <use xlink:href="#DejaVuSans-73" x="141.894531"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 90.6 61034.045913 
+L 95.25 61034.045913 
+L 95.25 112.405754 
+L 90.6 112.405754 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165 61034.045913 
+L 169.65 61034.045913 
+L 169.65 117.225937 
+L 165 117.225937 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 239.4 61034.045913 
+L 244.05 61034.045913 
+L 244.05 132.270186 
+L 239.4 132.270186 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 313.8 61034.045913 
+L 318.45 61034.045913 
+L 318.45 171.639561 
+L 313.8 171.639561 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 388.2 61034.045913 
+L 392.85 61034.045913 
+L 392.85 206.273129 
+L 388.2 206.273129 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 462.6 61034.045913 
+L 467.25 61034.045913 
+L 467.25 276.451418 
+L 462.6 276.451418 
+z
+" clip-path="url(#p6664958aee)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 95.25 61034.045913 
+L 99.9 61034.045913 
+L 99.9 116.746408 
+L 95.25 116.746408 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 169.65 61034.045913 
+L 174.3 61034.045913 
+L 174.3 120.768803 
+L 169.65 120.768803 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 244.05 61034.045913 
+L 248.7 61034.045913 
+L 248.7 134.644996 
+L 244.05 134.644996 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 318.45 61034.045913 
+L 323.1 61034.045913 
+L 323.1 172.559932 
+L 318.45 172.559932 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 392.85 61034.045913 
+L 397.5 61034.045913 
+L 397.5 206.975404 
+L 392.85 206.975404 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 467.25 61034.045913 
+L 471.9 61034.045913 
+L 471.9 276.472651 
+L 467.25 276.472651 
+z
+" clip-path="url(#p6664958aee)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 99.9 61034.045913 
+L 104.55 61034.045913 
+L 104.55 63.893907 
+L 99.9 63.893907 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 174.3 61034.045913 
+L 178.95 61034.045913 
+L 178.95 67.338733 
+L 174.3 67.338733 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 248.7 61034.045913 
+L 253.35 61034.045913 
+L 253.35 113.416168 
+L 248.7 113.416168 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 323.1 61034.045913 
+L 327.75 61034.045913 
+L 327.75 167.944619 
+L 323.1 167.944619 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 397.5 61034.045913 
+L 402.15 61034.045913 
+L 402.15 211.88259 
+L 397.5 211.88259 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 471.9 61034.045913 
+L 476.55 61034.045913 
+L 476.55 276.062473 
+L 471.9 276.062473 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 104.55 61034.045913 
+L 109.2 61034.045913 
+L 109.2 68.231422 
+L 104.55 68.231422 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 178.95 61034.045913 
+L 183.6 61034.045913 
+L 183.6 71.55809 
+L 178.95 71.55809 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 253.35 61034.045913 
+L 258 61034.045913 
+L 258 113.389194 
+L 253.35 113.389194 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 327.75 61034.045913 
+L 332.4 61034.045913 
+L 332.4 167.902473 
+L 327.75 167.902473 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 402.15 61034.045913 
+L 406.8 61034.045913 
+L 406.8 211.88259 
+L 402.15 211.88259 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 476.55 61034.045913 
+L 481.2 61034.045913 
+L 481.2 276.062473 
+L 476.55 276.062473 
+z
+" clip-path="url(#p6664958aee)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 109.2 61034.045913 
+L 113.85 61034.045913 
+L 113.85 54.852244 
+L 109.2 54.852244 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 183.6 61034.045913 
+L 188.25 61034.045913 
+L 188.25 65.336533 
+L 183.6 65.336533 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 258 61034.045913 
+L 262.65 61034.045913 
+L 262.65 114.65734 
+L 258 114.65734 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 332.4 61034.045913 
+L 337.05 61034.045913 
+L 337.05 175.395119 
+L 332.4 175.395119 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 406.8 61034.045913 
+L 411.45 61034.045913 
+L 411.45 211.888207 
+L 406.8 211.888207 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 481.2 61034.045913 
+L 485.85 61034.045913 
+L 485.85 276.118837 
+L 481.2 276.118837 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 113.85 61034.045913 
+L 118.5 61034.045913 
+L 118.5 57.17672 
+L 113.85 57.17672 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 188.25 61034.045913 
+L 192.9 61034.045913 
+L 192.9 59.588273 
+L 188.25 59.588273 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 262.65 61034.045913 
+L 267.3 61034.045913 
+L 267.3 113.189459 
+L 262.65 113.189459 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 337.05 61034.045913 
+L 341.7 61034.045913 
+L 341.7 175.395084 
+L 337.05 175.395084 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 411.45 61034.045913 
+L 416.1 61034.045913 
+L 416.1 211.888207 
+L 411.45 211.888207 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 485.85 61034.045913 
+L 490.5 61034.045913 
+L 490.5 276.118837 
+L 485.85 276.118837 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 118.5 61034.045913 
+L 123.15 61034.045913 
+L 123.15 54.327273 
+L 118.5 54.327273 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 192.9 61034.045913 
+L 197.55 61034.045913 
+L 197.55 65.91753 
+L 192.9 65.91753 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 267.3 61034.045913 
+L 271.95 61034.045913 
+L 271.95 120.657492 
+L 267.3 120.657492 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 341.7 61034.045913 
+L 346.35 61034.045913 
+L 346.35 175.399331 
+L 341.7 175.399331 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 416.1 61034.045913 
+L 420.75 61034.045913 
+L 420.75 211.905065 
+L 416.1 211.905065 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 490.5 61034.045913 
+L 495.15 61034.045913 
+L 495.15 276.872727 
+L 490.5 276.872727 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 123.15 61034.045913 
+L 127.8 61034.045913 
+L 127.8 56.782212 
+L 123.15 56.782212 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 197.55 61034.045913 
+L 202.2 61034.045913 
+L 202.2 65.914191 
+L 197.55 65.914191 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 271.95 61034.045913 
+L 276.6 61034.045913 
+L 276.6 120.367424 
+L 271.95 120.367424 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 346.35 61034.045913 
+L 351 61034.045913 
+L 351 175.399331 
+L 346.35 175.399331 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 420.75 61034.045913 
+L 425.4 61034.045913 
+L 425.4 211.905065 
+L 420.75 211.905065 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 495.15 61034.045913 
+L 499.8 61034.045913 
+L 499.8 276.26271 
+L 495.15 276.26271 
+z
+" clip-path="url(#p6664958aee)" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="line2d_85">
+    <path clip-path="url(#p6664958aee)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 72 288 
+L 72 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 518.4 288 
+L 518.4 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 72 288 
+L 518.4 288 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 72 43.2 
+L 518.4 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- Random read throughput (Bare Metal, 1 core) -->
+    <g transform="translate(158.094375 37.2) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-52"/>
+     <use xlink:href="#DejaVuSans-61" x="67.232422"/>
+     <use xlink:href="#DejaVuSans-6e" x="128.511719"/>
+     <use xlink:href="#DejaVuSans-64" x="191.890625"/>
+     <use xlink:href="#DejaVuSans-6f" x="255.367188"/>
+     <use xlink:href="#DejaVuSans-6d" x="316.548828"/>
+     <use xlink:href="#DejaVuSans-20" x="413.960938"/>
+     <use xlink:href="#DejaVuSans-72" x="445.748047"/>
+     <use xlink:href="#DejaVuSans-65" x="484.611328"/>
+     <use xlink:href="#DejaVuSans-61" x="546.134766"/>
+     <use xlink:href="#DejaVuSans-64" x="607.414062"/>
+     <use xlink:href="#DejaVuSans-20" x="670.890625"/>
+     <use xlink:href="#DejaVuSans-74" x="702.677734"/>
+     <use xlink:href="#DejaVuSans-68" x="741.886719"/>
+     <use xlink:href="#DejaVuSans-72" x="805.265625"/>
+     <use xlink:href="#DejaVuSans-6f" x="844.128906"/>
+     <use xlink:href="#DejaVuSans-75" x="905.310547"/>
+     <use xlink:href="#DejaVuSans-67" x="968.689453"/>
+     <use xlink:href="#DejaVuSans-68" x="1032.166016"/>
+     <use xlink:href="#DejaVuSans-70" x="1095.544922"/>
+     <use xlink:href="#DejaVuSans-75" x="1159.021484"/>
+     <use xlink:href="#DejaVuSans-74" x="1222.400391"/>
+     <use xlink:href="#DejaVuSans-20" x="1261.609375"/>
+     <use xlink:href="#DejaVuSans-28" x="1293.396484"/>
+     <use xlink:href="#DejaVuSans-42" x="1332.410156"/>
+     <use xlink:href="#DejaVuSans-61" x="1401.013672"/>
+     <use xlink:href="#DejaVuSans-72" x="1462.292969"/>
+     <use xlink:href="#DejaVuSans-65" x="1501.15625"/>
+     <use xlink:href="#DejaVuSans-20" x="1562.679688"/>
+     <use xlink:href="#DejaVuSans-4d" x="1594.466797"/>
+     <use xlink:href="#DejaVuSans-65" x="1680.746094"/>
+     <use xlink:href="#DejaVuSans-74" x="1742.269531"/>
+     <use xlink:href="#DejaVuSans-61" x="1781.478516"/>
+     <use xlink:href="#DejaVuSans-6c" x="1842.757812"/>
+     <use xlink:href="#DejaVuSans-2c" x="1870.541016"/>
+     <use xlink:href="#DejaVuSans-20" x="1902.328125"/>
+     <use xlink:href="#DejaVuSans-31" x="1934.115234"/>
+     <use xlink:href="#DejaVuSans-20" x="1997.738281"/>
+     <use xlink:href="#DejaVuSans-63" x="2029.525391"/>
+     <use xlink:href="#DejaVuSans-6f" x="2084.505859"/>
+     <use xlink:href="#DejaVuSans-72" x="2145.6875"/>
+     <use xlink:href="#DejaVuSans-65" x="2184.550781"/>
+     <use xlink:href="#DejaVuSans-29" x="2246.074219"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_55">
+     <path d="M 385.08125 183.303125 
+L 511.4 183.303125 
+Q 513.4 183.303125 513.4 181.303125 
+L 513.4 50.2 
+Q 513.4 48.2 511.4 48.2 
+L 385.08125 48.2 
+Q 383.08125 48.2 383.08125 50.2 
+L 383.08125 181.303125 
+Q 383.08125 183.303125 385.08125 183.303125 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_14">
+     <!-- Configuration (lang, QD) -->
+     <g transform="translate(387.08125 59.798437) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-6e" x="131.005859"/>
+      <use xlink:href="#DejaVuSans-66" x="194.384766"/>
+      <use xlink:href="#DejaVuSans-69" x="229.589844"/>
+      <use xlink:href="#DejaVuSans-67" x="257.373047"/>
+      <use xlink:href="#DejaVuSans-75" x="320.849609"/>
+      <use xlink:href="#DejaVuSans-72" x="384.228516"/>
+      <use xlink:href="#DejaVuSans-61" x="425.341797"/>
+      <use xlink:href="#DejaVuSans-74" x="486.621094"/>
+      <use xlink:href="#DejaVuSans-69" x="525.830078"/>
+      <use xlink:href="#DejaVuSans-6f" x="553.613281"/>
+      <use xlink:href="#DejaVuSans-6e" x="614.794922"/>
+      <use xlink:href="#DejaVuSans-20" x="678.173828"/>
+      <use xlink:href="#DejaVuSans-28" x="709.960938"/>
+      <use xlink:href="#DejaVuSans-6c" x="748.974609"/>
+      <use xlink:href="#DejaVuSans-61" x="776.757812"/>
+      <use xlink:href="#DejaVuSans-6e" x="838.037109"/>
+      <use xlink:href="#DejaVuSans-67" x="901.416016"/>
+      <use xlink:href="#DejaVuSans-2c" x="964.892578"/>
+      <use xlink:href="#DejaVuSans-20" x="996.679688"/>
+      <use xlink:href="#DejaVuSans-51" x="1028.466797"/>
+      <use xlink:href="#DejaVuSans-44" x="1107.177734"/>
+      <use xlink:href="#DejaVuSans-29" x="1184.179688"/>
+     </g>
+    </g>
+    <g id="patch_56">
+     <path d="M 410.535937 74.476562 
+L 430.535937 74.476562 
+L 430.535937 67.476562 
+L 410.535937 67.476562 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_15">
+     <!-- C, 1 -->
+     <g transform="translate(438.535937 74.476562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-31" x="133.398438"/>
+     </g>
+    </g>
+    <g id="patch_57">
+     <path d="M 410.535937 89.154688 
+L 430.535937 89.154688 
+L 430.535937 82.154688 
+L 410.535937 82.154688 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_16">
+     <!-- Rust, 1 -->
+     <g transform="translate(438.535937 89.154688) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-31" x="283.244141"/>
+     </g>
+    </g>
+    <g id="patch_58">
+     <path d="M 410.535937 103.832812 
+L 430.535937 103.832812 
+L 430.535937 96.832812 
+L 410.535937 96.832812 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_17">
+     <!-- C, 8 -->
+     <g transform="translate(438.535937 103.832812) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-38" x="133.398438"/>
+     </g>
+    </g>
+    <g id="patch_59">
+     <path d="M 410.535937 118.510938 
+L 430.535937 118.510938 
+L 430.535937 111.510938 
+L 410.535937 111.510938 
+z
+" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_18">
+     <!-- Rust, 8 -->
+     <g transform="translate(438.535937 118.510938) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-38" x="283.244141"/>
+     </g>
+    </g>
+    <g id="patch_60">
+     <path d="M 410.535937 133.189063 
+L 430.535937 133.189063 
+L 430.535937 126.189063 
+L 410.535937 126.189063 
+z
+" style="fill: url(#h30423827aa); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_19">
+     <!-- C, 32 -->
+     <g transform="translate(438.535937 133.189063) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-33" x="133.398438"/>
+      <use xlink:href="#DejaVuSans-32" x="197.021484"/>
+     </g>
+    </g>
+    <g id="patch_61">
+     <path d="M 410.535937 147.867188 
+L 430.535937 147.867188 
+L 430.535937 140.867188 
+L 410.535937 140.867188 
+z
+" style="fill: url(#hafa64dcd44); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- Rust, 32 -->
+     <g transform="translate(438.535937 147.867188) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-33" x="283.244141"/>
+      <use xlink:href="#DejaVuSans-32" x="346.867188"/>
+     </g>
+    </g>
+    <g id="patch_62">
+     <path d="M 410.535937 162.545312 
+L 430.535937 162.545312 
+L 430.535937 155.545312 
+L 410.535937 155.545312 
+z
+" style="fill: url(#h222d08f4ea); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <!-- C, 128 -->
+     <g transform="translate(438.535937 162.545312) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-2c" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-20" x="101.611328"/>
+      <use xlink:href="#DejaVuSans-31" x="133.398438"/>
+      <use xlink:href="#DejaVuSans-32" x="197.021484"/>
+      <use xlink:href="#DejaVuSans-38" x="260.644531"/>
+     </g>
+    </g>
+    <g id="patch_63">
+     <path d="M 410.535937 177.223437 
+L 430.535937 177.223437 
+L 430.535937 170.223437 
+L 410.535937 170.223437 
+z
+" style="fill: url(#he5d6e563fc); stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <!-- Rust, 128 -->
+     <g transform="translate(438.535937 177.223437) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-73" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-74" x="180.460938"/>
+      <use xlink:href="#DejaVuSans-2c" x="219.669922"/>
+      <use xlink:href="#DejaVuSans-20" x="251.457031"/>
+      <use xlink:href="#DejaVuSans-31" x="283.244141"/>
+      <use xlink:href="#DejaVuSans-32" x="346.867188"/>
+      <use xlink:href="#DejaVuSans-38" x="410.490234"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6664958aee">
+   <rect x="72" y="43.2" width="446.4" height="244.8"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h30423827aa" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#72ab97"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="hafa64dcd44" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#728ca6"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="h222d08f4ea" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#ffdcaa"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+  <pattern id="he5d6e563fc" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#ffc6aa"/>
+   <path d="M -36 36 
+L 36 -36 
+M -30 42 
+L 42 -30 
+M -24 48 
+L 48 -24 
+M -18 54 
+L 54 -18 
+M -12 60 
+L 60 -12 
+M -6 66 
+L 66 -6 
+M 0 72 
+L 72 0 
+M 6 78 
+L 78 6 
+M 12 84 
+L 84 12 
+M 18 90 
+L 90 18 
+M 24 96 
+L 96 24 
+M 30 102 
+L 102 30 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/src/rnvme/nvme-v6.12-rc2-relative.svg
+++ b/src/rnvme/nvme-v6.12-rc2-relative.svg
@@ -1,0 +1,1880 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="360pt" viewBox="0 0 432 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 432 360 
+L 432 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54 288 
+L 388.8 288 
+L 388.8 43.2 
+L 54 43.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 81.9 288 
+L 81.9 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mb09a42da5e" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb09a42da5e" x="81.9" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 512 B -->
+      <g transform="translate(66.677317 320.968497) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-42" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 137.7 288 
+L 137.7 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mb09a42da5e" x="137.7" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 4 KiB -->
+      <g transform="translate(124.873746 318.572067) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4b" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4b" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="160.986328"/>
+       <use xlink:href="#DejaVuSans-42" x="188.769531"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 193.5 288 
+L 193.5 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mb09a42da5e" x="193.5" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 32 KiB -->
+      <g transform="translate(176.174779 323.071034) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4b" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="224.609375"/>
+       <use xlink:href="#DejaVuSans-42" x="252.392578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 249.3 288 
+L 249.3 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mb09a42da5e" x="249.3" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 256 KiB -->
+      <g transform="translate(227.475812 327.570001) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-4b" x="222.65625"/>
+       <use xlink:href="#DejaVuSans-69" x="288.232422"/>
+       <use xlink:href="#DejaVuSans-42" x="316.015625"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 305.1 288 
+L 305.1 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mb09a42da5e" x="305.1" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 MiB -->
+      <g transform="translate(290.809814 320.035999) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-20" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-4d" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-69" x="181.689453"/>
+       <use xlink:href="#DejaVuSans-42" x="209.472656"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 360.9 288 
+L 360.9 43.2 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mb09a42da5e" x="360.9" y="288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 16 MiB -->
+      <g transform="translate(342.110847 324.534966) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-20" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-4d" x="159.033203"/>
+       <use xlink:href="#DejaVuSans-69" x="245.3125"/>
+       <use xlink:href="#DejaVuSans-42" x="273.095703"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Block size -->
+     <g transform="translate(196.592969 340.639) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6c" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-6f" x="96.386719"/>
+      <use xlink:href="#DejaVuSans-63" x="157.568359"/>
+      <use xlink:href="#DejaVuSans-6b" x="212.548828"/>
+      <use xlink:href="#DejaVuSans-20" x="270.458984"/>
+      <use xlink:href="#DejaVuSans-73" x="302.246094"/>
+      <use xlink:href="#DejaVuSans-69" x="354.345703"/>
+      <use xlink:href="#DejaVuSans-7a" x="382.128906"/>
+      <use xlink:href="#DejaVuSans-65" x="434.619141"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <path d="M 54 275.17602 
+L 388.8 275.17602 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <defs>
+       <path id="m350a46597c" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="275.17602" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- −0.15 -->
+      <g transform="translate(16.354687 278.975238) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 54 247.336498 
+L 388.8 247.336498 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="247.336498" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- −0.10 -->
+      <g transform="translate(16.354687 251.135717) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-31" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 54 219.496976 
+L 388.8 219.496976 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="219.496976" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- −0.05 -->
+      <g transform="translate(16.354687 223.296195) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 54 191.657455 
+L 388.8 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="191.657455" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.00 -->
+      <g transform="translate(24.734375 195.456674) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_21">
+      <path d="M 54 163.817933 
+L 388.8 163.817933 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="163.817933" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.05 -->
+      <g transform="translate(24.734375 167.617152) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <path d="M 54 135.978412 
+L 388.8 135.978412 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="135.978412" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.10 -->
+      <g transform="translate(24.734375 139.77763) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_25">
+      <path d="M 54 108.13889 
+L 388.8 108.13889 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="108.13889" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.15 -->
+      <g transform="translate(24.734375 111.938109) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_27">
+      <path d="M 54 80.299368 
+L 388.8 80.299368 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="80.299368" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.20 -->
+      <g transform="translate(24.734375 84.098587) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_29">
+      <path d="M 54 52.459847 
+L 388.8 52.459847 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m350a46597c" x="54" y="52.459847" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.25 -->
+      <g transform="translate(24.734375 56.259066) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 54 261.256259 
+L 388.8 261.256259 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <defs>
+       <path id="mf4ac0d5054" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="261.256259" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 54 233.416737 
+L 388.8 233.416737 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="233.416737" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 54 205.577216 
+L 388.8 205.577216 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="205.577216" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_37">
+      <path d="M 54 177.737694 
+L 388.8 177.737694 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="177.737694" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 54 149.898172 
+L 388.8 149.898172 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="149.898172" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 54 122.058651 
+L 388.8 122.058651 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="122.058651" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 54 94.219129 
+L 388.8 94.219129 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="94.219129" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 54 66.379608 
+L 388.8 66.379608 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mf4ac0d5054" x="54" y="66.379608" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- Relative difference -->
+     <g transform="translate(10.275 212.527344) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-65" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-6c" x="126.505859"/>
+      <use xlink:href="#DejaVuSans-61" x="154.289062"/>
+      <use xlink:href="#DejaVuSans-74" x="215.568359"/>
+      <use xlink:href="#DejaVuSans-69" x="254.777344"/>
+      <use xlink:href="#DejaVuSans-76" x="282.560547"/>
+      <use xlink:href="#DejaVuSans-65" x="341.740234"/>
+      <use xlink:href="#DejaVuSans-20" x="403.263672"/>
+      <use xlink:href="#DejaVuSans-64" x="435.050781"/>
+      <use xlink:href="#DejaVuSans-69" x="498.527344"/>
+      <use xlink:href="#DejaVuSans-66" x="526.310547"/>
+      <use xlink:href="#DejaVuSans-66" x="561.515625"/>
+      <use xlink:href="#DejaVuSans-65" x="596.720703"/>
+      <use xlink:href="#DejaVuSans-72" x="658.244141"/>
+      <use xlink:href="#DejaVuSans-65" x="697.107422"/>
+      <use xlink:href="#DejaVuSans-6e" x="758.630859"/>
+      <use xlink:href="#DejaVuSans-63" x="822.009766"/>
+      <use xlink:href="#DejaVuSans-65" x="876.990234"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 67.95 191.657455 
+L 74.925 191.657455 
+L 74.925 276.315841 
+L 67.95 276.315841 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 123.75 191.657455 
+L 130.725 191.657455 
+L 130.725 261.784857 
+L 123.75 261.784857 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 179.55 191.657455 
+L 186.525 191.657455 
+L 186.525 239.699208 
+L 179.55 239.699208 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 235.35 191.657455 
+L 242.325 191.657455 
+L 242.325 210.792434 
+L 235.35 210.792434 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 291.15 191.657455 
+L 298.125 191.657455 
+L 298.125 206.318425 
+L 291.15 206.318425 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 346.95 191.657455 
+L 353.925 191.657455 
+L 353.925 192.106479 
+L 346.95 192.106479 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 74.925 191.657455 
+L 81.9 191.657455 
+L 81.9 276.259524 
+L 74.925 276.259524 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 130.725 191.657455 
+L 137.7 191.657455 
+L 137.7 274.134819 
+L 130.725 274.134819 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 186.525 191.657455 
+L 193.5 191.657455 
+L 193.5 191.08649 
+L 186.525 191.08649 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 242.325 191.657455 
+L 249.3 191.657455 
+L 249.3 190.7651 
+L 242.325 190.7651 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 298.125 191.657455 
+L 305.1 191.657455 
+L 305.1 191.657455 
+L 298.125 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 353.925 191.657455 
+L 360.9 191.657455 
+L 360.9 191.657455 
+L 353.925 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 81.9 191.657455 
+L 88.875 191.657455 
+L 88.875 238.725273 
+L 81.9 238.725273 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 137.7 191.657455 
+L 144.675 191.657455 
+L 144.675 55.743421 
+L 137.7 55.743421 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 193.5 191.657455 
+L 200.475 191.657455 
+L 200.475 159.720362 
+L 193.5 159.720362 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 249.3 191.657455 
+L 256.275 191.657455 
+L 256.275 191.656712 
+L 249.3 191.656712 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 305.1 191.657455 
+L 312.075 191.657455 
+L 312.075 191.657455 
+L 305.1 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 360.9 191.657455 
+L 367.875 191.657455 
+L 367.875 191.657455 
+L 360.9 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 88.875 191.657455 
+L 95.85 191.657455 
+L 95.85 241.245805 
+L 88.875 241.245805 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 144.675 191.657455 
+L 151.65 191.657455 
+L 151.65 191.586802 
+L 144.675 191.586802 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 200.475 191.657455 
+L 207.45 191.657455 
+L 207.45 185.486795 
+L 200.475 185.486795 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 256.275 191.657455 
+L 263.25 191.657455 
+L 263.25 191.657455 
+L 256.275 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 312.075 191.657455 
+L 319.05 191.657455 
+L 319.05 191.657455 
+L 312.075 191.657455 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 367.875 191.657455 
+L 374.85 191.657455 
+L 374.85 178.601098 
+L 367.875 178.601098 
+z
+" clip-path="url(#pb011aa1c24)" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 71.4375 276.872727 
+L 71.4375 275.758955 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 127.2375 262.186384 
+L 127.2375 261.383331 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 183.0375 240.106318 
+L 183.0375 239.292098 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 238.8375 210.945212 
+L 238.8375 210.639656 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 294.6375 206.755442 
+L 294.6375 205.881408 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 350.4375 192.315905 
+L 350.4375 191.897053 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_47">
+    <defs>
+     <path id="mc82a1399e5" d="M 1.5 0 
+L -1.5 -0 
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="71.4375" y="276.872727" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="127.2375" y="262.186384" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="183.0375" y="240.106318" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="238.8375" y="210.945212" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="294.6375" y="206.755442" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="350.4375" y="192.315905" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_48">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="71.4375" y="275.758955" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="127.2375" y="261.383331" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="183.0375" y="239.292098" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="238.8375" y="210.639656" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="294.6375" y="205.881408" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="350.4375" y="191.897053" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 78.4125 276.791378 
+L 78.4125 275.72767 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 134.2125 274.724341 
+L 134.2125 273.545297 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 190.0125 191.223266 
+L 190.0125 190.949714 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 245.8125 190.901673 
+L 245.8125 190.628526 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 301.6125 191.657455 
+L 301.6125 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 357.4125 191.657455 
+L 357.4125 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_49">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="78.4125" y="276.791378" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="134.2125" y="274.724341" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="190.0125" y="191.223266" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="245.8125" y="190.901673" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="301.6125" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="357.4125" y="191.657455" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_50">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="78.4125" y="275.72767" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="134.2125" y="273.545297" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="190.0125" y="190.949714" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="245.8125" y="190.628526" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="301.6125" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="357.4125" y="191.657455" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 85.3875 240.119958 
+L 85.3875 237.330589 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 141.1875 57.15957 
+L 141.1875 54.327273 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 196.9875 160.668985 
+L 196.9875 158.771739 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 252.7875 191.658213 
+L 252.7875 191.655211 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 308.5875 191.657455 
+L 308.5875 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 364.3875 191.863956 
+L 364.3875 191.450953 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_51">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="85.3875" y="240.119958" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="141.1875" y="57.15957" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="196.9875" y="160.668985" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="252.7875" y="191.658213" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="308.5875" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="364.3875" y="191.863956" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_52">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="85.3875" y="237.330589" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="141.1875" y="54.327273" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="196.9875" y="158.771739" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="252.7875" y="191.655211" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="308.5875" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="364.3875" y="191.450953" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 92.3625 242.765392 
+L 92.3625 239.726218 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 148.1625 191.669569 
+L 148.1625 191.504035 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 203.9625 185.90569 
+L 203.9625 185.0679 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 259.7625 191.657455 
+L 259.7625 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 315.5625 191.657455 
+L 315.5625 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+    <path d="M 371.3625 180.085922 
+L 371.3625 177.116274 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5"/>
+   </g>
+   <g id="line2d_53">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="92.3625" y="242.765392" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="148.1625" y="191.669569" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="203.9625" y="185.90569" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="259.7625" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="315.5625" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="371.3625" y="180.085922" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_54">
+    <g clip-path="url(#pb011aa1c24)">
+     <use xlink:href="#mc82a1399e5" x="92.3625" y="239.726218" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="148.1625" y="191.504035" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="203.9625" y="185.0679" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="259.7625" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="315.5625" y="191.657455" style="stroke: #000000"/>
+     <use xlink:href="#mc82a1399e5" x="371.3625" y="177.116274" style="stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_55">
+    <path d="M 54 191.657455 
+L 388.8 191.657455 
+" clip-path="url(#pb011aa1c24)" style="fill: none; stroke: #000000; stroke-width: 0.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 54 288 
+L 54 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 388.8 288 
+L 388.8 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 54 288 
+L 388.8 288 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 54 43.2 
+L 388.8 43.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_18">
+   <!-- NVMe randread, $\frac{R-C}{C}$ (Bare Metal, 1 core) -->
+   <g transform="translate(91.98 18.84) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-56" d="M 1831 0 
+L 50 4666 
+L 709 4666 
+L 2188 738 
+L 3669 4666 
+L 4325 4666 
+L 2547 0 
+L 1831 0 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-43" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4e" transform="translate(0 0.254687)"/>
+    <use xlink:href="#DejaVuSans-56" transform="translate(74.804688 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(143.212891 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(229.492188 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(291.015625 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(322.802734 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(363.916016 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(425.195312 0.254687)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(488.574219 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(552.050781 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(593.164062 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(654.6875 0.254687)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(715.966797 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(779.443359 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(811.230469 0.254687)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(843.017578 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-2212" transform="translate(905.292969 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(977.583008 45.046875) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-Oblique-43" transform="translate(910.017578 -39.151563) scale(0.7)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1038.959961 0.254687)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(1070.74707 0.254687)"/>
+    <use xlink:href="#DejaVuSans-42" transform="translate(1109.760742 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1178.364258 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1239.643555 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1280.756836 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1342.280273 0.254687)"/>
+    <use xlink:href="#DejaVuSans-4d" transform="translate(1374.067383 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1460.34668 0.254687)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1521.870117 0.254687)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1561.079102 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1622.358398 0.254687)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1650.141602 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1681.928711 0.254687)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1713.71582 0.254687)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1777.338867 0.254687)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1809.125977 0.254687)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1864.106445 0.254687)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1925.288086 0.254687)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1966.401367 0.254687)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(2027.924805 0.254687)"/>
+    <path d="M 843.017578 19.051563 
+L 843.017578 25.301563 
+L 1026.459961 25.301563 
+L 1026.459961 19.051563 
+L 843.017578 19.051563 
+z
+"/>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="patch_31">
+    <path d="M 355.860937 81.390625 
+L 425 81.390625 
+Q 427 81.390625 427 79.390625 
+L 427 7 
+Q 427 5 425 5 
+L 355.860937 5 
+Q 353.860937 5 353.860937 7 
+L 353.860937 79.390625 
+Q 353.860937 81.390625 355.860937 81.390625 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_19">
+    <!-- Queue depth -->
+    <g transform="translate(357.860937 16.598437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-51" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 3406 84 
+L 4238 -825 
+L 3475 -825 
+L 2784 -78 
+Q 2681 -84 2626 -87 
+Q 2572 -91 2522 -91 
+Q 1538 -91 948 567 
+Q 359 1225 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1516 4351 937 
+Q 4025 359 3406 84 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-51"/>
+     <use xlink:href="#DejaVuSans-75" x="78.710938"/>
+     <use xlink:href="#DejaVuSans-65" x="142.089844"/>
+     <use xlink:href="#DejaVuSans-75" x="203.613281"/>
+     <use xlink:href="#DejaVuSans-65" x="266.992188"/>
+     <use xlink:href="#DejaVuSans-20" x="328.515625"/>
+     <use xlink:href="#DejaVuSans-64" x="360.302734"/>
+     <use xlink:href="#DejaVuSans-65" x="423.779297"/>
+     <use xlink:href="#DejaVuSans-70" x="485.302734"/>
+     <use xlink:href="#DejaVuSans-74" x="548.779297"/>
+     <use xlink:href="#DejaVuSans-68" x="587.988281"/>
+    </g>
+   </g>
+   <g id="patch_32">
+    <path d="M 366.886719 31.276563 
+L 386.886719 31.276563 
+L 386.886719 24.276563 
+L 366.886719 24.276563 
+z
+" style="fill: #72ab97; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_20">
+    <!-- 1 -->
+    <g transform="translate(394.886719 31.276563) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="patch_33">
+    <path d="M 366.886719 45.954688 
+L 386.886719 45.954688 
+L 386.886719 38.954688 
+L 366.886719 38.954688 
+z
+" style="fill: #728ca6; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_21">
+    <!-- 8 -->
+    <g transform="translate(394.886719 45.954688) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+    </g>
+   </g>
+   <g id="patch_34">
+    <path d="M 366.886719 60.632812 
+L 386.886719 60.632812 
+L 386.886719 53.632812 
+L 366.886719 53.632812 
+z
+" style="fill: #ffdcaa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <!-- 32 -->
+    <g transform="translate(394.886719 60.632812) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+    </g>
+   </g>
+   <g id="patch_35">
+    <path d="M 366.886719 75.310938 
+L 386.886719 75.310938 
+L 386.886719 68.310938 
+L 366.886719 68.310938 
+z
+" style="fill: #ffc6aa; stroke: #000000; stroke-width: 0.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- 128 -->
+    <g transform="translate(394.886719 75.310938) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+     <use xlink:href="#DejaVuSans-38" x="127.246094"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb011aa1c24">
+   <rect x="54" y="43.2" width="334.8" height="244.8"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
Please pull this update with benchmark results for v6.11 and v6.12-rc2 for `rnull` and `rnvme`.

This PR also adds a nix flake with the tools required to build the website.