### PR TITLE
rename pinned-init to pin-init

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -18,7 +18,7 @@
 ## Subprojects
 
   - [`klint`](klint.md)
-  - [`pinned-init`](pinned-init.md)
+  - [`pin-init`](pin-init.md)
   - Hidden [The Safe Pinned Initialization Problem](The-Safe-Pinned-Initialization-Problem.md)
   - Hidden [`Arc` in the Linux kernel](Arc-in-the-Linux-kernel.md)
   - Hidden [Ksquirrel](Ksquirrel.md)

--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,10 @@ git-repository-url = "https://github.com/Rust-for-Linux/rust-for-linux.com"
 edit-url-template = ""
 no-section-label = true
 
+[output.html.redirect]
+"/pinned-init" = "/pin-init"
+"/pinned-init.html" = "/pin-init"
+
 [output.html.fold]
 enable = true
 level = 0

--- a/src/pin-init.md
+++ b/src/pin-init.md
@@ -1,0 +1,5 @@
+# `pin-init`
+
+[`pin-init`](https://github.com/Rust-for-Linux/pin-init) is a solution to [The Safe Pinned Initialization Problem](The-Safe-Pinned-Initialization-Problem.md). It provides safe and fallible initialization of pinned structs using in-place constructors.
+
+The main developer and maintainer is Benno Lossin ([y86-dev](https://github.com/y86-dev/)).

--- a/src/pinned-init.md
+++ b/src/pinned-init.md
@@ -1,5 +1,0 @@
-# `pinned-init`
-
-[`pinned-init`](https://github.com/Rust-for-Linux/pinned-init) is a solution to [The Safe Pinned Initialization Problem](The-Safe-Pinned-Initialization-Problem.md). It provides safe and fallible initialization of pinned structs using in-place constructors.
-
-The main developer and maintainer is y86-dev.


### PR DESCRIPTION
After renaming the `pin-init` repo, we can merge this.