### PR TITLE
Update "gccrs" page's timeline informations.

### DIFF
--- a/src/gccrs.md
+++ b/src/gccrs.md
@@ -4,9 +4,9 @@
 programming language, developed from the ground up for the
 [GNU Compiler Collection (GCC)](https://gcc.gnu.org) project.
 
-While `gccrs` is not yet able to compile Rust code, it is progressing fast — we are hoping we will be able to compile the Rust 1.49 standard library by the next GCC release, 14.1.
+While `gccrs` is not yet able to compile Rust code, it is progressing fast — we are hoping we will be able to compile the Rust 1.49 `core` library in 2025 and the standard library with the GCC 16.1 release.
 
-Once that milestone is achieved, we will begin catching up to the Rust version used by Rust-for-Linux — in the hopes of being useful quickly!
+When `core` compiles properly, we will begin catching up to the Rust version used by Rust-for-Linux — in the hopes of being useful quickly!
 
 You can follow the project's progress on [our blog](https://rust-gcc.github.io).
 


### PR DESCRIPTION
The text was mentioning rust standard library support in gcc 14.1, which did not happen. However, we think we should be able to compile `core` by the end of the year.
I have also modified the text to reflect the fact that we'll start working on rfl features once core compiles correctly as we do not need to wait for a compete standard library support.